### PR TITLE
Fix several bugs in TLS-enabled connection handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ### Bug Fixes
 
- * Heartbeat monitor setup was unintentionally skipped
+ * NIO pipeline handler ordering caused a crash on TLS connections when opening a channel
+ * Heartbeat monitor could not observe inbound frames (any traffic counts for a heartbeat)
 
 
 ## 0.9.0 (Dec 29, 2025)

--- a/Sources/AMQPProtocol/Constants.swift
+++ b/Sources/AMQPProtocol/Constants.swift
@@ -15,10 +15,10 @@ public let amqpProtocolHeader = Data([0x41, 0x4D, 0x51, 0x50, 0x00, 0x00, 0x09, 
 
 /// Frame types in AMQP 0-9-1
 public enum FrameType: UInt8, Sendable {
-    case method = 1
-    case header = 2
-    case body = 3
-    case heartbeat = 8
+  case method = 1
+  case header = 2
+  case body = 3
+  case heartbeat = 8
 }
 
 /// Frame end marker
@@ -26,235 +26,235 @@ public let frameEnd: UInt8 = 0xCE
 
 /// Default frame size limits
 public enum FrameDefaults {
-    public static let minSize: UInt32 = 4096
-    public static let maxSize: UInt32 = 131072  // 128 KB
-    public static let headerSize: Int = 7  // type(1) + channel(2) + size(4)
+  public static let minSize: UInt32 = 4096
+  public static let maxSize: UInt32 = 131072  // 128 KB
+  public static let headerSize: Int = 7  // type(1) + channel(2) + size(4)
 }
 
 // MARK: - Class IDs
 
 /// AMQP method class IDs
 public enum ClassID: UInt16, Sendable {
-    case connection = 10
-    case channel = 20
-    case exchange = 40
-    case queue = 50
-    case basic = 60
-    case confirm = 85
-    case tx = 90
+  case connection = 10
+  case channel = 20
+  case exchange = 40
+  case queue = 50
+  case basic = 60
+  case confirm = 85
+  case tx = 90
 }
 
 // MARK: - Method IDs
 
 /// Connection class method IDs
 public enum ConnectionMethodID: UInt16, Sendable {
-    case start = 10
-    case startOk = 11
-    case secure = 20
-    case secureOk = 21
-    case tune = 30
-    case tuneOk = 31
-    case open = 40
-    case openOk = 41
-    case close = 50
-    case closeOk = 51
-    case blocked = 60
-    case unblocked = 61
-    case updateSecret = 70
-    case updateSecretOk = 71
+  case start = 10
+  case startOk = 11
+  case secure = 20
+  case secureOk = 21
+  case tune = 30
+  case tuneOk = 31
+  case open = 40
+  case openOk = 41
+  case close = 50
+  case closeOk = 51
+  case blocked = 60
+  case unblocked = 61
+  case updateSecret = 70
+  case updateSecretOk = 71
 }
 
 /// Channel class method IDs
 public enum ChannelMethodID: UInt16, Sendable {
-    case open = 10
-    case openOk = 11
-    case flow = 20
-    case flowOk = 21
-    case close = 40
-    case closeOk = 41
+  case open = 10
+  case openOk = 11
+  case flow = 20
+  case flowOk = 21
+  case close = 40
+  case closeOk = 41
 }
 
 /// Exchange class method IDs
 public enum ExchangeMethodID: UInt16, Sendable {
-    case declare = 10
-    case declareOk = 11
-    case delete = 20
-    case deleteOk = 21
-    case bind = 30
-    case bindOk = 31
-    case unbind = 40
-    case unbindOk = 51
+  case declare = 10
+  case declareOk = 11
+  case delete = 20
+  case deleteOk = 21
+  case bind = 30
+  case bindOk = 31
+  case unbind = 40
+  case unbindOk = 51
 }
 
 /// Queue class method IDs
 public enum QueueMethodID: UInt16, Sendable {
-    case declare = 10
-    case declareOk = 11
-    case bind = 20
-    case bindOk = 21
-    case purge = 30
-    case purgeOk = 31
-    case delete = 40
-    case deleteOk = 41
-    case unbind = 50
-    case unbindOk = 51
+  case declare = 10
+  case declareOk = 11
+  case bind = 20
+  case bindOk = 21
+  case purge = 30
+  case purgeOk = 31
+  case delete = 40
+  case deleteOk = 41
+  case unbind = 50
+  case unbindOk = 51
 }
 
 /// Basic class method IDs
 public enum BasicMethodID: UInt16, Sendable {
-    case qos = 10
-    case qosOk = 11
-    case consume = 20
-    case consumeOk = 21
-    case cancel = 30
-    case cancelOk = 31
-    case publish = 40
-    case `return` = 50
-    case deliver = 60
-    case get = 70
-    case getOk = 71
-    case getEmpty = 72
-    case ack = 80
-    case reject = 90
-    case recoverAsync = 100
-    case recover = 110
-    case recoverOk = 111
-    case nack = 120
+  case qos = 10
+  case qosOk = 11
+  case consume = 20
+  case consumeOk = 21
+  case cancel = 30
+  case cancelOk = 31
+  case publish = 40
+  case `return` = 50
+  case deliver = 60
+  case get = 70
+  case getOk = 71
+  case getEmpty = 72
+  case ack = 80
+  case reject = 90
+  case recoverAsync = 100
+  case recover = 110
+  case recoverOk = 111
+  case nack = 120
 }
 
 /// Tx class method IDs
 public enum TxMethodID: UInt16, Sendable {
-    case select = 10
-    case selectOk = 11
-    case commit = 20
-    case commitOk = 21
-    case rollback = 30
-    case rollbackOk = 31
+  case select = 10
+  case selectOk = 11
+  case commit = 20
+  case commitOk = 21
+  case rollback = 30
+  case rollbackOk = 31
 }
 
 /// Confirm class method IDs
 public enum ConfirmMethodID: UInt16, Sendable {
-    case select = 10
-    case selectOk = 11
+  case select = 10
+  case selectOk = 11
 }
 
 // MARK: - Reply Codes
 
 /// AMQP reply codes
 public enum ReplyCode: UInt16, Sendable {
-    // Success
-    case success = 200
+  // Success
+  case success = 200
 
-    // Soft errors (channel closed)
-    case contentTooLarge = 311
-    case noRoute = 312
-    case noConsumers = 313
-    case accessRefused = 403
-    case notFound = 404
-    case resourceLocked = 405
-    case preconditionFailed = 406
+  // Soft errors (channel closed)
+  case contentTooLarge = 311
+  case noRoute = 312
+  case noConsumers = 313
+  case accessRefused = 403
+  case notFound = 404
+  case resourceLocked = 405
+  case preconditionFailed = 406
 
-    // Hard errors (connection closed)
-    case connectionForced = 320
-    case invalidPath = 402
-    case frameError = 501
-    case syntaxError = 502
-    case commandInvalid = 503
-    case channelError = 504
-    case unexpectedFrame = 505
-    case resourceError = 506
-    case notAllowed = 530
-    case notImplemented = 540
-    case internalError = 541
+  // Hard errors (connection closed)
+  case connectionForced = 320
+  case invalidPath = 402
+  case frameError = 501
+  case syntaxError = 502
+  case commandInvalid = 503
+  case channelError = 504
+  case unexpectedFrame = 505
+  case resourceError = 506
+  case notAllowed = 530
+  case notImplemented = 540
+  case internalError = 541
 
-    /// Whether this is a soft error (channel-level)
-    public var isSoftError: Bool {
-        switch self {
-        case .contentTooLarge, .noRoute, .noConsumers,
-             .accessRefused, .notFound, .resourceLocked, .preconditionFailed:
-            return true
-        default:
-            return false
-        }
+  /// Whether this is a soft error (channel-level)
+  public var isSoftError: Bool {
+    switch self {
+    case .contentTooLarge, .noRoute, .noConsumers,
+      .accessRefused, .notFound, .resourceLocked, .preconditionFailed:
+      return true
+    default:
+      return false
     }
+  }
 
-    /// Whether this is a hard error (connection-level)
-    public var isHardError: Bool {
-        switch self {
-        case .connectionForced, .invalidPath, .frameError, .syntaxError,
-             .commandInvalid, .channelError, .unexpectedFrame, .resourceError,
-             .notAllowed, .notImplemented, .internalError:
-            return true
-        default:
-            return false
-        }
+  /// Whether this is a hard error (connection-level)
+  public var isHardError: Bool {
+    switch self {
+    case .connectionForced, .invalidPath, .frameError, .syntaxError,
+      .commandInvalid, .channelError, .unexpectedFrame, .resourceError,
+      .notAllowed, .notImplemented, .internalError:
+      return true
+    default:
+      return false
     }
+  }
 }
 
 // MARK: - Field Value Type Tags
 
 /// AMQP table field value type tags
 public enum FieldValueTag: UInt8, Sendable {
-    case boolean = 0x74        // 't'
-    case signedInt8 = 0x62     // 'b'
-    case unsignedInt8 = 0x42   // 'B'  (RabbitMQ extension)
-    case signedInt16 = 0x73    // 's'
-    case unsignedInt16 = 0x75  // 'u'  (RabbitMQ extension)
-    case signedInt32 = 0x49    // 'I'
-    case unsignedInt32 = 0x69  // 'i'  (RabbitMQ extension)
-    case signedInt64 = 0x6C    // 'l'
-    case float32 = 0x66        // 'f'
-    case float64 = 0x64        // 'd'
-    case decimal = 0x44        // 'D'
-    // shortString uses same tag as signedInt16 (0x73), not used separately
-    case longString = 0x53     // 'S'
-    case array = 0x41          // 'A'
-    case timestamp = 0x54      // 'T'
-    case table = 0x46          // 'F'
-    case byteArray = 0x78      // 'x'
-    case void = 0x56           // 'V'
+  case boolean = 0x74  // 't'
+  case signedInt8 = 0x62  // 'b'
+  case unsignedInt8 = 0x42  // 'B'  (RabbitMQ extension)
+  case signedInt16 = 0x73  // 's'
+  case unsignedInt16 = 0x75  // 'u'  (RabbitMQ extension)
+  case signedInt32 = 0x49  // 'I'
+  case unsignedInt32 = 0x69  // 'i'  (RabbitMQ extension)
+  case signedInt64 = 0x6C  // 'l'
+  case float32 = 0x66  // 'f'
+  case float64 = 0x64  // 'd'
+  case decimal = 0x44  // 'D'
+  // shortString uses same tag as signedInt16 (0x73), not used separately
+  case longString = 0x53  // 'S'
+  case array = 0x41  // 'A'
+  case timestamp = 0x54  // 'T'
+  case table = 0x46  // 'F'
+  case byteArray = 0x78  // 'x'
+  case void = 0x56  // 'V'
 }
 
 // MARK: - Basic Properties Flags
 
 /// Property flags for BasicProperties (14 optional properties)
 public struct PropertyFlags: OptionSet, Sendable {
-    public let rawValue: UInt16
+  public let rawValue: UInt16
 
-    public init(rawValue: UInt16) {
-        self.rawValue = rawValue
-    }
+  public init(rawValue: UInt16) {
+    self.rawValue = rawValue
+  }
 
-    public static let contentType = PropertyFlags(rawValue: 1 << 15)
-    public static let contentEncoding = PropertyFlags(rawValue: 1 << 14)
-    public static let headers = PropertyFlags(rawValue: 1 << 13)
-    public static let deliveryMode = PropertyFlags(rawValue: 1 << 12)
-    public static let priority = PropertyFlags(rawValue: 1 << 11)
-    public static let correlationId = PropertyFlags(rawValue: 1 << 10)
-    public static let replyTo = PropertyFlags(rawValue: 1 << 9)
-    public static let expiration = PropertyFlags(rawValue: 1 << 8)
-    public static let messageId = PropertyFlags(rawValue: 1 << 7)
-    public static let timestamp = PropertyFlags(rawValue: 1 << 6)
-    public static let type = PropertyFlags(rawValue: 1 << 5)
-    public static let userId = PropertyFlags(rawValue: 1 << 4)
-    public static let appId = PropertyFlags(rawValue: 1 << 3)
-    public static let clusterId = PropertyFlags(rawValue: 1 << 2)  // deprecated
+  public static let contentType = PropertyFlags(rawValue: 1 << 15)
+  public static let contentEncoding = PropertyFlags(rawValue: 1 << 14)
+  public static let headers = PropertyFlags(rawValue: 1 << 13)
+  public static let deliveryMode = PropertyFlags(rawValue: 1 << 12)
+  public static let priority = PropertyFlags(rawValue: 1 << 11)
+  public static let correlationId = PropertyFlags(rawValue: 1 << 10)
+  public static let replyTo = PropertyFlags(rawValue: 1 << 9)
+  public static let expiration = PropertyFlags(rawValue: 1 << 8)
+  public static let messageId = PropertyFlags(rawValue: 1 << 7)
+  public static let timestamp = PropertyFlags(rawValue: 1 << 6)
+  public static let type = PropertyFlags(rawValue: 1 << 5)
+  public static let userId = PropertyFlags(rawValue: 1 << 4)
+  public static let appId = PropertyFlags(rawValue: 1 << 3)
+  public static let clusterId = PropertyFlags(rawValue: 1 << 2)  // deprecated
 }
 
 // MARK: - Exchange Types
 
 /// Standard AMQP exchange types
 public enum ExchangeTypeName: String, Sendable {
-    case direct = "direct"
-    case fanout = "fanout"
-    case topic = "topic"
-    case headers = "headers"
+  case direct = "direct"
+  case fanout = "fanout"
+  case topic = "topic"
+  case headers = "headers"
 }
 
 // MARK: - Delivery Mode
 
 /// Message delivery mode
 public enum DeliveryMode: UInt8, Sendable {
-    case transient = 1
-    case persistent = 2
+  case transient = 1
+  case persistent = 2
 }

--- a/Sources/AMQPProtocol/Frame.swift
+++ b/Sources/AMQPProtocol/Frame.swift
@@ -13,907 +13,910 @@ import Foundation
 
 /// AMQP frame variants
 public enum Frame: Sendable, Equatable {
-    /// Method frame containing an AMQP method
-    case method(channelID: UInt16, method: Method)
+  /// Method frame containing an AMQP method
+  case method(channelID: UInt16, method: Method)
 
-    /// Content header frame with message properties
-    case header(channelID: UInt16, classID: UInt16, bodySize: UInt64, properties: BasicProperties)
+  /// Content header frame with message properties
+  case header(channelID: UInt16, classID: UInt16, bodySize: UInt64, properties: BasicProperties)
 
-    /// Content body frame with message payload
-    case body(channelID: UInt16, payload: Data)
+  /// Content body frame with message payload
+  case body(channelID: UInt16, payload: Data)
 
-    /// Heartbeat frame (always on channel 0)
-    case heartbeat
+  /// Heartbeat frame (always on channel 0)
+  case heartbeat
 
-    /// Channel ID for this frame
-    public var channelID: UInt16 {
-        switch self {
-        case .method(let id, _): return id
-        case .header(let id, _, _, _): return id
-        case .body(let id, _): return id
-        case .heartbeat: return 0
-        }
+  /// Channel ID for this frame
+  public var channelID: UInt16 {
+    switch self {
+    case .method(let id, _): return id
+    case .header(let id, _, _, _): return id
+    case .body(let id, _): return id
+    case .heartbeat: return 0
     }
+  }
 
-    /// Frame type
-    public var frameType: FrameType {
-        switch self {
-        case .method: return .method
-        case .header: return .header
-        case .body: return .body
-        case .heartbeat: return .heartbeat
-        }
+  /// Frame type
+  public var frameType: FrameType {
+    switch self {
+    case .method: return .method
+    case .header: return .header
+    case .body: return .body
+    case .heartbeat: return .heartbeat
     }
+  }
 }
 
 // MARK: - Method Identification
 
 /// Identifies an AMQP method by class and method ID
 public struct MethodID: Sendable, Equatable, Hashable {
-    public let classID: UInt16
-    public let methodID: UInt16
+  public let classID: UInt16
+  public let methodID: UInt16
 
-    public init(classID: UInt16, methodID: UInt16) {
-        self.classID = classID
-        self.methodID = methodID
-    }
+  public init(classID: UInt16, methodID: UInt16) {
+    self.classID = classID
+    self.methodID = methodID
+  }
 
-    /// Combined index: (classID << 16) | methodID
-    public var index: UInt32 {
-        (UInt32(classID) << 16) | UInt32(methodID)
-    }
+  /// Combined index: (classID << 16) | methodID
+  public var index: UInt32 {
+    (UInt32(classID) << 16) | UInt32(methodID)
+  }
 }
 
 // MARK: - Method
 
 /// AMQP method payload
 public enum Method: Sendable, Equatable {
-    // Connection class (10)
-    case connectionStart(ConnectionStart)
-    case connectionStartOk(ConnectionStartOk)
-    case connectionSecure(ConnectionSecure)
-    case connectionSecureOk(ConnectionSecureOk)
-    case connectionTune(ConnectionTune)
-    case connectionTuneOk(ConnectionTuneOk)
-    case connectionOpen(ConnectionOpen)
-    case connectionOpenOk(ConnectionOpenOk)
-    case connectionClose(ConnectionClose)
-    case connectionCloseOk
-    case connectionBlocked(ConnectionBlocked)
-    case connectionUnblocked
+  // Connection class (10)
+  case connectionStart(ConnectionStart)
+  case connectionStartOk(ConnectionStartOk)
+  case connectionSecure(ConnectionSecure)
+  case connectionSecureOk(ConnectionSecureOk)
+  case connectionTune(ConnectionTune)
+  case connectionTuneOk(ConnectionTuneOk)
+  case connectionOpen(ConnectionOpen)
+  case connectionOpenOk(ConnectionOpenOk)
+  case connectionClose(ConnectionClose)
+  case connectionCloseOk
+  case connectionBlocked(ConnectionBlocked)
+  case connectionUnblocked
 
-    // Channel class (20)
-    case channelOpen(ChannelOpen)
-    case channelOpenOk(ChannelOpenOk)
-    case channelFlow(ChannelFlow)
-    case channelFlowOk(ChannelFlowOk)
-    case channelClose(ChannelClose)
-    case channelCloseOk
+  // Channel class (20)
+  case channelOpen(ChannelOpen)
+  case channelOpenOk(ChannelOpenOk)
+  case channelFlow(ChannelFlow)
+  case channelFlowOk(ChannelFlowOk)
+  case channelClose(ChannelClose)
+  case channelCloseOk
 
-    // Exchange class (40)
-    case exchangeDeclare(ExchangeDeclare)
-    case exchangeDeclareOk
-    case exchangeDelete(ExchangeDelete)
-    case exchangeDeleteOk
-    case exchangeBind(ExchangeBind)
-    case exchangeBindOk
-    case exchangeUnbind(ExchangeUnbind)
-    case exchangeUnbindOk
+  // Exchange class (40)
+  case exchangeDeclare(ExchangeDeclare)
+  case exchangeDeclareOk
+  case exchangeDelete(ExchangeDelete)
+  case exchangeDeleteOk
+  case exchangeBind(ExchangeBind)
+  case exchangeBindOk
+  case exchangeUnbind(ExchangeUnbind)
+  case exchangeUnbindOk
 
-    // Queue class (50)
-    case queueDeclare(QueueDeclare)
-    case queueDeclareOk(QueueDeclareOk)
-    case queueBind(QueueBind)
-    case queueBindOk
-    case queueUnbind(QueueUnbind)
-    case queueUnbindOk
-    case queuePurge(QueuePurge)
-    case queuePurgeOk(QueuePurgeOk)
-    case queueDelete(QueueDelete)
-    case queueDeleteOk(QueueDeleteOk)
+  // Queue class (50)
+  case queueDeclare(QueueDeclare)
+  case queueDeclareOk(QueueDeclareOk)
+  case queueBind(QueueBind)
+  case queueBindOk
+  case queueUnbind(QueueUnbind)
+  case queueUnbindOk
+  case queuePurge(QueuePurge)
+  case queuePurgeOk(QueuePurgeOk)
+  case queueDelete(QueueDelete)
+  case queueDeleteOk(QueueDeleteOk)
 
-    // Basic class (60)
-    case basicQos(BasicQos)
-    case basicQosOk
-    case basicConsume(BasicConsume)
-    case basicConsumeOk(BasicConsumeOk)
-    case basicCancel(BasicCancel)
-    case basicCancelOk(BasicCancelOk)
-    case basicPublish(BasicPublish)
-    case basicReturn(BasicReturn)
-    case basicDeliver(BasicDeliver)
-    case basicGet(BasicGet)
-    case basicGetOk(BasicGetOk)
-    case basicGetEmpty(BasicGetEmpty)
-    case basicAck(BasicAck)
-    case basicReject(BasicReject)
-    case basicRecoverAsync(BasicRecoverAsync)
-    case basicRecover(BasicRecover)
-    case basicRecoverOk
-    case basicNack(BasicNack)
+  // Basic class (60)
+  case basicQos(BasicQos)
+  case basicQosOk
+  case basicConsume(BasicConsume)
+  case basicConsumeOk(BasicConsumeOk)
+  case basicCancel(BasicCancel)
+  case basicCancelOk(BasicCancelOk)
+  case basicPublish(BasicPublish)
+  case basicReturn(BasicReturn)
+  case basicDeliver(BasicDeliver)
+  case basicGet(BasicGet)
+  case basicGetOk(BasicGetOk)
+  case basicGetEmpty(BasicGetEmpty)
+  case basicAck(BasicAck)
+  case basicReject(BasicReject)
+  case basicRecoverAsync(BasicRecoverAsync)
+  case basicRecover(BasicRecover)
+  case basicRecoverOk
+  case basicNack(BasicNack)
 
-    // Tx class (90)
-    case txSelect
-    case txSelectOk
-    case txCommit
-    case txCommitOk
-    case txRollback
-    case txRollbackOk
+  // Tx class (90)
+  case txSelect
+  case txSelectOk
+  case txCommit
+  case txCommitOk
+  case txRollback
+  case txRollbackOk
 
-    // Confirm class (85)
-    case confirmSelect(ConfirmSelect)
-    case confirmSelectOk
+  // Confirm class (85)
+  case confirmSelect(ConfirmSelect)
+  case confirmSelectOk
 
-    /// Method identifier
-    public var methodID: MethodID {
-        switch self {
-        // Connection
-        case .connectionStart: return MethodID(classID: 10, methodID: 10)
-        case .connectionStartOk: return MethodID(classID: 10, methodID: 11)
-        case .connectionSecure: return MethodID(classID: 10, methodID: 20)
-        case .connectionSecureOk: return MethodID(classID: 10, methodID: 21)
-        case .connectionTune: return MethodID(classID: 10, methodID: 30)
-        case .connectionTuneOk: return MethodID(classID: 10, methodID: 31)
-        case .connectionOpen: return MethodID(classID: 10, methodID: 40)
-        case .connectionOpenOk: return MethodID(classID: 10, methodID: 41)
-        case .connectionClose: return MethodID(classID: 10, methodID: 50)
-        case .connectionCloseOk: return MethodID(classID: 10, methodID: 51)
-        case .connectionBlocked: return MethodID(classID: 10, methodID: 60)
-        case .connectionUnblocked: return MethodID(classID: 10, methodID: 61)
+  /// Method identifier
+  public var methodID: MethodID {
+    switch self {
+    // Connection
+    case .connectionStart: return MethodID(classID: 10, methodID: 10)
+    case .connectionStartOk: return MethodID(classID: 10, methodID: 11)
+    case .connectionSecure: return MethodID(classID: 10, methodID: 20)
+    case .connectionSecureOk: return MethodID(classID: 10, methodID: 21)
+    case .connectionTune: return MethodID(classID: 10, methodID: 30)
+    case .connectionTuneOk: return MethodID(classID: 10, methodID: 31)
+    case .connectionOpen: return MethodID(classID: 10, methodID: 40)
+    case .connectionOpenOk: return MethodID(classID: 10, methodID: 41)
+    case .connectionClose: return MethodID(classID: 10, methodID: 50)
+    case .connectionCloseOk: return MethodID(classID: 10, methodID: 51)
+    case .connectionBlocked: return MethodID(classID: 10, methodID: 60)
+    case .connectionUnblocked: return MethodID(classID: 10, methodID: 61)
 
-        // Channel
-        case .channelOpen: return MethodID(classID: 20, methodID: 10)
-        case .channelOpenOk: return MethodID(classID: 20, methodID: 11)
-        case .channelFlow: return MethodID(classID: 20, methodID: 20)
-        case .channelFlowOk: return MethodID(classID: 20, methodID: 21)
-        case .channelClose: return MethodID(classID: 20, methodID: 40)
-        case .channelCloseOk: return MethodID(classID: 20, methodID: 41)
+    // Channel
+    case .channelOpen: return MethodID(classID: 20, methodID: 10)
+    case .channelOpenOk: return MethodID(classID: 20, methodID: 11)
+    case .channelFlow: return MethodID(classID: 20, methodID: 20)
+    case .channelFlowOk: return MethodID(classID: 20, methodID: 21)
+    case .channelClose: return MethodID(classID: 20, methodID: 40)
+    case .channelCloseOk: return MethodID(classID: 20, methodID: 41)
 
-        // Exchange
-        case .exchangeDeclare: return MethodID(classID: 40, methodID: 10)
-        case .exchangeDeclareOk: return MethodID(classID: 40, methodID: 11)
-        case .exchangeDelete: return MethodID(classID: 40, methodID: 20)
-        case .exchangeDeleteOk: return MethodID(classID: 40, methodID: 21)
-        case .exchangeBind: return MethodID(classID: 40, methodID: 30)
-        case .exchangeBindOk: return MethodID(classID: 40, methodID: 31)
-        case .exchangeUnbind: return MethodID(classID: 40, methodID: 40)
-        case .exchangeUnbindOk: return MethodID(classID: 40, methodID: 51)
+    // Exchange
+    case .exchangeDeclare: return MethodID(classID: 40, methodID: 10)
+    case .exchangeDeclareOk: return MethodID(classID: 40, methodID: 11)
+    case .exchangeDelete: return MethodID(classID: 40, methodID: 20)
+    case .exchangeDeleteOk: return MethodID(classID: 40, methodID: 21)
+    case .exchangeBind: return MethodID(classID: 40, methodID: 30)
+    case .exchangeBindOk: return MethodID(classID: 40, methodID: 31)
+    case .exchangeUnbind: return MethodID(classID: 40, methodID: 40)
+    case .exchangeUnbindOk: return MethodID(classID: 40, methodID: 51)
 
-        // Queue
-        case .queueDeclare: return MethodID(classID: 50, methodID: 10)
-        case .queueDeclareOk: return MethodID(classID: 50, methodID: 11)
-        case .queueBind: return MethodID(classID: 50, methodID: 20)
-        case .queueBindOk: return MethodID(classID: 50, methodID: 21)
-        case .queueUnbind: return MethodID(classID: 50, methodID: 50)
-        case .queueUnbindOk: return MethodID(classID: 50, methodID: 51)
-        case .queuePurge: return MethodID(classID: 50, methodID: 30)
-        case .queuePurgeOk: return MethodID(classID: 50, methodID: 31)
-        case .queueDelete: return MethodID(classID: 50, methodID: 40)
-        case .queueDeleteOk: return MethodID(classID: 50, methodID: 41)
+    // Queue
+    case .queueDeclare: return MethodID(classID: 50, methodID: 10)
+    case .queueDeclareOk: return MethodID(classID: 50, methodID: 11)
+    case .queueBind: return MethodID(classID: 50, methodID: 20)
+    case .queueBindOk: return MethodID(classID: 50, methodID: 21)
+    case .queueUnbind: return MethodID(classID: 50, methodID: 50)
+    case .queueUnbindOk: return MethodID(classID: 50, methodID: 51)
+    case .queuePurge: return MethodID(classID: 50, methodID: 30)
+    case .queuePurgeOk: return MethodID(classID: 50, methodID: 31)
+    case .queueDelete: return MethodID(classID: 50, methodID: 40)
+    case .queueDeleteOk: return MethodID(classID: 50, methodID: 41)
 
-        // Basic
-        case .basicQos: return MethodID(classID: 60, methodID: 10)
-        case .basicQosOk: return MethodID(classID: 60, methodID: 11)
-        case .basicConsume: return MethodID(classID: 60, methodID: 20)
-        case .basicConsumeOk: return MethodID(classID: 60, methodID: 21)
-        case .basicCancel: return MethodID(classID: 60, methodID: 30)
-        case .basicCancelOk: return MethodID(classID: 60, methodID: 31)
-        case .basicPublish: return MethodID(classID: 60, methodID: 40)
-        case .basicReturn: return MethodID(classID: 60, methodID: 50)
-        case .basicDeliver: return MethodID(classID: 60, methodID: 60)
-        case .basicGet: return MethodID(classID: 60, methodID: 70)
-        case .basicGetOk: return MethodID(classID: 60, methodID: 71)
-        case .basicGetEmpty: return MethodID(classID: 60, methodID: 72)
-        case .basicAck: return MethodID(classID: 60, methodID: 80)
-        case .basicReject: return MethodID(classID: 60, methodID: 90)
-        case .basicRecoverAsync: return MethodID(classID: 60, methodID: 100)
-        case .basicRecover: return MethodID(classID: 60, methodID: 110)
-        case .basicRecoverOk: return MethodID(classID: 60, methodID: 111)
-        case .basicNack: return MethodID(classID: 60, methodID: 120)
+    // Basic
+    case .basicQos: return MethodID(classID: 60, methodID: 10)
+    case .basicQosOk: return MethodID(classID: 60, methodID: 11)
+    case .basicConsume: return MethodID(classID: 60, methodID: 20)
+    case .basicConsumeOk: return MethodID(classID: 60, methodID: 21)
+    case .basicCancel: return MethodID(classID: 60, methodID: 30)
+    case .basicCancelOk: return MethodID(classID: 60, methodID: 31)
+    case .basicPublish: return MethodID(classID: 60, methodID: 40)
+    case .basicReturn: return MethodID(classID: 60, methodID: 50)
+    case .basicDeliver: return MethodID(classID: 60, methodID: 60)
+    case .basicGet: return MethodID(classID: 60, methodID: 70)
+    case .basicGetOk: return MethodID(classID: 60, methodID: 71)
+    case .basicGetEmpty: return MethodID(classID: 60, methodID: 72)
+    case .basicAck: return MethodID(classID: 60, methodID: 80)
+    case .basicReject: return MethodID(classID: 60, methodID: 90)
+    case .basicRecoverAsync: return MethodID(classID: 60, methodID: 100)
+    case .basicRecover: return MethodID(classID: 60, methodID: 110)
+    case .basicRecoverOk: return MethodID(classID: 60, methodID: 111)
+    case .basicNack: return MethodID(classID: 60, methodID: 120)
 
-        // Tx
-        case .txSelect: return MethodID(classID: 90, methodID: 10)
-        case .txSelectOk: return MethodID(classID: 90, methodID: 11)
-        case .txCommit: return MethodID(classID: 90, methodID: 20)
-        case .txCommitOk: return MethodID(classID: 90, methodID: 21)
-        case .txRollback: return MethodID(classID: 90, methodID: 30)
-        case .txRollbackOk: return MethodID(classID: 90, methodID: 31)
+    // Tx
+    case .txSelect: return MethodID(classID: 90, methodID: 10)
+    case .txSelectOk: return MethodID(classID: 90, methodID: 11)
+    case .txCommit: return MethodID(classID: 90, methodID: 20)
+    case .txCommitOk: return MethodID(classID: 90, methodID: 21)
+    case .txRollback: return MethodID(classID: 90, methodID: 30)
+    case .txRollbackOk: return MethodID(classID: 90, methodID: 31)
 
-        // Confirm
-        case .confirmSelect: return MethodID(classID: 85, methodID: 10)
-        case .confirmSelectOk: return MethodID(classID: 85, methodID: 11)
-        }
+    // Confirm
+    case .confirmSelect: return MethodID(classID: 85, methodID: 10)
+    case .confirmSelectOk: return MethodID(classID: 85, methodID: 11)
     }
+  }
 
-    /// Whether this method expects a response
-    public var expectsResponse: Bool {
-        switch self {
-        case .connectionStartOk, .connectionSecureOk, .connectionTuneOk,
-             .connectionOpen, .connectionClose,
-             .channelOpen, .channelFlow, .channelClose,
-             .exchangeDeclare, .exchangeDelete, .exchangeBind, .exchangeUnbind,
-             .queueDeclare, .queueBind, .queueUnbind, .queuePurge, .queueDelete,
-             .basicQos, .basicConsume, .basicCancel, .basicGet, .basicRecover,
-             .txSelect, .txCommit, .txRollback,
-             .confirmSelect:
-            return true
-        default:
-            return false
-        }
+  /// Whether this method expects a response
+  public var expectsResponse: Bool {
+    switch self {
+    case .connectionStartOk, .connectionSecureOk, .connectionTuneOk,
+      .connectionOpen, .connectionClose,
+      .channelOpen, .channelFlow, .channelClose,
+      .exchangeDeclare, .exchangeDelete, .exchangeBind, .exchangeUnbind,
+      .queueDeclare, .queueBind, .queueUnbind, .queuePurge, .queueDelete,
+      .basicQos, .basicConsume, .basicCancel, .basicGet, .basicRecover,
+      .txSelect, .txCommit, .txRollback,
+      .confirmSelect:
+      return true
+    default:
+      return false
     }
+  }
 
-    /// Whether this method carries content (header + body frames follow)
-    public var hasContent: Bool {
-        switch self {
-        case .basicPublish, .basicReturn, .basicDeliver, .basicGetOk:
-            return true
-        default:
-            return false
-        }
+  /// Whether this method carries content (header + body frames follow)
+  public var hasContent: Bool {
+    switch self {
+    case .basicPublish, .basicReturn, .basicDeliver, .basicGetOk:
+      return true
+    default:
+      return false
     }
+  }
 }
 
 // MARK: - Method Payload Structures
 
 // Connection class payloads
 public struct ConnectionStart: Sendable, Equatable {
-    public var versionMajor: UInt8
-    public var versionMinor: UInt8
-    public var serverProperties: Table
-    public var mechanisms: String
-    public var locales: String
+  public var versionMajor: UInt8
+  public var versionMinor: UInt8
+  public var serverProperties: Table
+  public var mechanisms: String
+  public var locales: String
 
-    public init(
-        versionMajor: UInt8 = 0,
-        versionMinor: UInt8 = 9,
-        serverProperties: Table = [:],
-        mechanisms: String = "PLAIN",
-        locales: String = "en_US"
-    ) {
-        self.versionMajor = versionMajor
-        self.versionMinor = versionMinor
-        self.serverProperties = serverProperties
-        self.mechanisms = mechanisms
-        self.locales = locales
-    }
+  public init(
+    versionMajor: UInt8 = 0,
+    versionMinor: UInt8 = 9,
+    serverProperties: Table = [:],
+    mechanisms: String = "PLAIN",
+    locales: String = "en_US"
+  ) {
+    self.versionMajor = versionMajor
+    self.versionMinor = versionMinor
+    self.serverProperties = serverProperties
+    self.mechanisms = mechanisms
+    self.locales = locales
+  }
 }
 
 public struct ConnectionStartOk: Sendable, Equatable {
-    public var clientProperties: Table
-    public var mechanism: String
-    public var response: String
-    public var locale: String
+  public var clientProperties: Table
+  public var mechanism: String
+  public var response: String
+  public var locale: String
 
-    public init(
-        clientProperties: Table = [:],
-        mechanism: String = "PLAIN",
-        response: String,
-        locale: String = "en_US"
-    ) {
-        self.clientProperties = clientProperties
-        self.mechanism = mechanism
-        self.response = response
-        self.locale = locale
-    }
+  public init(
+    clientProperties: Table = [:],
+    mechanism: String = "PLAIN",
+    response: String,
+    locale: String = "en_US"
+  ) {
+    self.clientProperties = clientProperties
+    self.mechanism = mechanism
+    self.response = response
+    self.locale = locale
+  }
 
-    /// Create PLAIN auth response
-    public static func plainAuth(username: String, password: String, clientProperties: Table = [:]) -> ConnectionStartOk {
-        // PLAIN format: \0username\0password
-        let response = "\0\(username)\0\(password)"
-        return ConnectionStartOk(
-            clientProperties: clientProperties,
-            mechanism: "PLAIN",
-            response: response,
-            locale: "en_US"
-        )
-    }
+  /// Create PLAIN auth response
+  public static func plainAuth(username: String, password: String, clientProperties: Table = [:])
+    -> ConnectionStartOk
+  {
+    // PLAIN format: \0username\0password
+    let response = "\0\(username)\0\(password)"
+    return ConnectionStartOk(
+      clientProperties: clientProperties,
+      mechanism: "PLAIN",
+      response: response,
+      locale: "en_US"
+    )
+  }
 }
 
 public struct ConnectionSecure: Sendable, Equatable {
-    public var challenge: String
+  public var challenge: String
 
-    public init(challenge: String) {
-        self.challenge = challenge
-    }
+  public init(challenge: String) {
+    self.challenge = challenge
+  }
 }
 
 public struct ConnectionSecureOk: Sendable, Equatable {
-    public var response: String
+  public var response: String
 
-    public init(response: String) {
-        self.response = response
-    }
+  public init(response: String) {
+    self.response = response
+  }
 }
 
 public struct ConnectionTune: Sendable, Equatable {
-    public var channelMax: UInt16
-    public var frameMax: UInt32
-    public var heartbeat: UInt16
+  public var channelMax: UInt16
+  public var frameMax: UInt32
+  public var heartbeat: UInt16
 
-    public init(channelMax: UInt16 = 2047, frameMax: UInt32 = 131072, heartbeat: UInt16 = 60) {
-        self.channelMax = channelMax
-        self.frameMax = frameMax
-        self.heartbeat = heartbeat
-    }
+  public init(channelMax: UInt16 = 2047, frameMax: UInt32 = 131072, heartbeat: UInt16 = 60) {
+    self.channelMax = channelMax
+    self.frameMax = frameMax
+    self.heartbeat = heartbeat
+  }
 }
 
 public struct ConnectionTuneOk: Sendable, Equatable {
-    public var channelMax: UInt16
-    public var frameMax: UInt32
-    public var heartbeat: UInt16
+  public var channelMax: UInt16
+  public var frameMax: UInt32
+  public var heartbeat: UInt16
 
-    public init(channelMax: UInt16 = 2047, frameMax: UInt32 = 131072, heartbeat: UInt16 = 60) {
-        self.channelMax = channelMax
-        self.frameMax = frameMax
-        self.heartbeat = heartbeat
-    }
+  public init(channelMax: UInt16 = 2047, frameMax: UInt32 = 131072, heartbeat: UInt16 = 60) {
+    self.channelMax = channelMax
+    self.frameMax = frameMax
+    self.heartbeat = heartbeat
+  }
 }
 
 public struct ConnectionOpen: Sendable, Equatable {
-    public var virtualHost: String
-    public var reserved1: String
-    public var reserved2: Bool
+  public var virtualHost: String
+  public var reserved1: String
+  public var reserved2: Bool
 
-    public init(virtualHost: String = "/", reserved1: String = "", reserved2: Bool = false) {
-        self.virtualHost = virtualHost
-        self.reserved1 = reserved1
-        self.reserved2 = reserved2
-    }
+  public init(virtualHost: String = "/", reserved1: String = "", reserved2: Bool = false) {
+    self.virtualHost = virtualHost
+    self.reserved1 = reserved1
+    self.reserved2 = reserved2
+  }
 }
 
 public struct ConnectionOpenOk: Sendable, Equatable {
-    public var reserved1: String
+  public var reserved1: String
 
-    public init(reserved1: String = "") {
-        self.reserved1 = reserved1
-    }
+  public init(reserved1: String = "") {
+    self.reserved1 = reserved1
+  }
 }
 
 public struct ConnectionClose: Sendable, Equatable {
-    public var replyCode: UInt16
-    public var replyText: String
-    public var classId: UInt16
-    public var methodId: UInt16
+  public var replyCode: UInt16
+  public var replyText: String
+  public var classId: UInt16
+  public var methodId: UInt16
 
-    public init(replyCode: UInt16, replyText: String, classId: UInt16 = 0, methodId: UInt16 = 0) {
-        self.replyCode = replyCode
-        self.replyText = replyText
-        self.classId = classId
-        self.methodId = methodId
-    }
+  public init(replyCode: UInt16, replyText: String, classId: UInt16 = 0, methodId: UInt16 = 0) {
+    self.replyCode = replyCode
+    self.replyText = replyText
+    self.classId = classId
+    self.methodId = methodId
+  }
 }
 
 public struct ConnectionBlocked: Sendable, Equatable {
-    public var reason: String
+  public var reason: String
 
-    public init(reason: String) {
-        self.reason = reason
-    }
+  public init(reason: String) {
+    self.reason = reason
+  }
 }
 
 // Channel class payloads
 public struct ChannelOpen: Sendable, Equatable {
-    public var reserved1: String
+  public var reserved1: String
 
-    public init(reserved1: String = "") {
-        self.reserved1 = reserved1
-    }
+  public init(reserved1: String = "") {
+    self.reserved1 = reserved1
+  }
 }
 
 public struct ChannelOpenOk: Sendable, Equatable {
-    public var reserved1: String
+  public var reserved1: String
 
-    public init(reserved1: String = "") {
-        self.reserved1 = reserved1
-    }
+  public init(reserved1: String = "") {
+    self.reserved1 = reserved1
+  }
 }
 
 public struct ChannelFlow: Sendable, Equatable {
-    public var active: Bool
+  public var active: Bool
 
-    public init(active: Bool) {
-        self.active = active
-    }
+  public init(active: Bool) {
+    self.active = active
+  }
 }
 
 public struct ChannelFlowOk: Sendable, Equatable {
-    public var active: Bool
+  public var active: Bool
 
-    public init(active: Bool) {
-        self.active = active
-    }
+  public init(active: Bool) {
+    self.active = active
+  }
 }
 
 public struct ChannelClose: Sendable, Equatable {
-    public var replyCode: UInt16
-    public var replyText: String
-    public var classId: UInt16
-    public var methodId: UInt16
+  public var replyCode: UInt16
+  public var replyText: String
+  public var classId: UInt16
+  public var methodId: UInt16
 
-    public init(replyCode: UInt16, replyText: String, classId: UInt16 = 0, methodId: UInt16 = 0) {
-        self.replyCode = replyCode
-        self.replyText = replyText
-        self.classId = classId
-        self.methodId = methodId
-    }
+  public init(replyCode: UInt16, replyText: String, classId: UInt16 = 0, methodId: UInt16 = 0) {
+    self.replyCode = replyCode
+    self.replyText = replyText
+    self.classId = classId
+    self.methodId = methodId
+  }
 }
 
 // Exchange class payloads
 public struct ExchangeDeclare: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var exchange: String
-    public var type: String
-    public var passive: Bool
-    public var durable: Bool
-    public var autoDelete: Bool
-    public var `internal`: Bool
-    public var noWait: Bool
-    public var arguments: Table
+  public var reserved1: UInt16
+  public var exchange: String
+  public var type: String
+  public var passive: Bool
+  public var durable: Bool
+  public var autoDelete: Bool
+  public var `internal`: Bool
+  public var noWait: Bool
+  public var arguments: Table
 
-    public init(
-        reserved1: UInt16 = 0,
-        exchange: String,
-        type: String = "direct",
-        passive: Bool = false,
-        durable: Bool = false,
-        autoDelete: Bool = false,
-        internal: Bool = false,
-        noWait: Bool = false,
-        arguments: Table = [:]
-    ) {
-        self.reserved1 = reserved1
-        self.exchange = exchange
-        self.type = type
-        self.passive = passive
-        self.durable = durable
-        self.autoDelete = autoDelete
-        self.internal = `internal`
-        self.noWait = noWait
-        self.arguments = arguments
-    }
+  public init(
+    reserved1: UInt16 = 0,
+    exchange: String,
+    type: String = "direct",
+    passive: Bool = false,
+    durable: Bool = false,
+    autoDelete: Bool = false,
+    internal: Bool = false,
+    noWait: Bool = false,
+    arguments: Table = [:]
+  ) {
+    self.reserved1 = reserved1
+    self.exchange = exchange
+    self.type = type
+    self.passive = passive
+    self.durable = durable
+    self.autoDelete = autoDelete
+    self.internal = `internal`
+    self.noWait = noWait
+    self.arguments = arguments
+  }
 }
 
 public struct ExchangeDelete: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var exchange: String
-    public var ifUnused: Bool
-    public var noWait: Bool
+  public var reserved1: UInt16
+  public var exchange: String
+  public var ifUnused: Bool
+  public var noWait: Bool
 
-    public init(reserved1: UInt16 = 0, exchange: String, ifUnused: Bool = false, noWait: Bool = false) {
-        self.reserved1 = reserved1
-        self.exchange = exchange
-        self.ifUnused = ifUnused
-        self.noWait = noWait
-    }
+  public init(reserved1: UInt16 = 0, exchange: String, ifUnused: Bool = false, noWait: Bool = false)
+  {
+    self.reserved1 = reserved1
+    self.exchange = exchange
+    self.ifUnused = ifUnused
+    self.noWait = noWait
+  }
 }
 
 public struct ExchangeBind: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var destination: String
-    public var source: String
-    public var routingKey: String
-    public var noWait: Bool
-    public var arguments: Table
+  public var reserved1: UInt16
+  public var destination: String
+  public var source: String
+  public var routingKey: String
+  public var noWait: Bool
+  public var arguments: Table
 
-    public init(
-        reserved1: UInt16 = 0,
-        destination: String,
-        source: String,
-        routingKey: String = "",
-        noWait: Bool = false,
-        arguments: Table = [:]
-    ) {
-        self.reserved1 = reserved1
-        self.destination = destination
-        self.source = source
-        self.routingKey = routingKey
-        self.noWait = noWait
-        self.arguments = arguments
-    }
+  public init(
+    reserved1: UInt16 = 0,
+    destination: String,
+    source: String,
+    routingKey: String = "",
+    noWait: Bool = false,
+    arguments: Table = [:]
+  ) {
+    self.reserved1 = reserved1
+    self.destination = destination
+    self.source = source
+    self.routingKey = routingKey
+    self.noWait = noWait
+    self.arguments = arguments
+  }
 }
 
 public struct ExchangeUnbind: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var destination: String
-    public var source: String
-    public var routingKey: String
-    public var noWait: Bool
-    public var arguments: Table
+  public var reserved1: UInt16
+  public var destination: String
+  public var source: String
+  public var routingKey: String
+  public var noWait: Bool
+  public var arguments: Table
 
-    public init(
-        reserved1: UInt16 = 0,
-        destination: String,
-        source: String,
-        routingKey: String = "",
-        noWait: Bool = false,
-        arguments: Table = [:]
-    ) {
-        self.reserved1 = reserved1
-        self.destination = destination
-        self.source = source
-        self.routingKey = routingKey
-        self.noWait = noWait
-        self.arguments = arguments
-    }
+  public init(
+    reserved1: UInt16 = 0,
+    destination: String,
+    source: String,
+    routingKey: String = "",
+    noWait: Bool = false,
+    arguments: Table = [:]
+  ) {
+    self.reserved1 = reserved1
+    self.destination = destination
+    self.source = source
+    self.routingKey = routingKey
+    self.noWait = noWait
+    self.arguments = arguments
+  }
 }
 
 // Queue class payloads
 public struct QueueDeclare: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var queue: String
-    public var passive: Bool
-    public var durable: Bool
-    public var exclusive: Bool
-    public var autoDelete: Bool
-    public var noWait: Bool
-    public var arguments: Table
+  public var reserved1: UInt16
+  public var queue: String
+  public var passive: Bool
+  public var durable: Bool
+  public var exclusive: Bool
+  public var autoDelete: Bool
+  public var noWait: Bool
+  public var arguments: Table
 
-    public init(
-        reserved1: UInt16 = 0,
-        queue: String = "",
-        passive: Bool = false,
-        durable: Bool = false,
-        exclusive: Bool = false,
-        autoDelete: Bool = false,
-        noWait: Bool = false,
-        arguments: Table = [:]
-    ) {
-        self.reserved1 = reserved1
-        self.queue = queue
-        self.passive = passive
-        self.durable = durable
-        self.exclusive = exclusive
-        self.autoDelete = autoDelete
-        self.noWait = noWait
-        self.arguments = arguments
-    }
+  public init(
+    reserved1: UInt16 = 0,
+    queue: String = "",
+    passive: Bool = false,
+    durable: Bool = false,
+    exclusive: Bool = false,
+    autoDelete: Bool = false,
+    noWait: Bool = false,
+    arguments: Table = [:]
+  ) {
+    self.reserved1 = reserved1
+    self.queue = queue
+    self.passive = passive
+    self.durable = durable
+    self.exclusive = exclusive
+    self.autoDelete = autoDelete
+    self.noWait = noWait
+    self.arguments = arguments
+  }
 }
 
 public struct QueueDeclareOk: Sendable, Equatable {
-    public var queue: String
-    public var messageCount: UInt32
-    public var consumerCount: UInt32
+  public var queue: String
+  public var messageCount: UInt32
+  public var consumerCount: UInt32
 
-    public init(queue: String, messageCount: UInt32 = 0, consumerCount: UInt32 = 0) {
-        self.queue = queue
-        self.messageCount = messageCount
-        self.consumerCount = consumerCount
-    }
+  public init(queue: String, messageCount: UInt32 = 0, consumerCount: UInt32 = 0) {
+    self.queue = queue
+    self.messageCount = messageCount
+    self.consumerCount = consumerCount
+  }
 }
 
 public struct QueueBind: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var queue: String
-    public var exchange: String
-    public var routingKey: String
-    public var noWait: Bool
-    public var arguments: Table
+  public var reserved1: UInt16
+  public var queue: String
+  public var exchange: String
+  public var routingKey: String
+  public var noWait: Bool
+  public var arguments: Table
 
-    public init(
-        reserved1: UInt16 = 0,
-        queue: String,
-        exchange: String,
-        routingKey: String = "",
-        noWait: Bool = false,
-        arguments: Table = [:]
-    ) {
-        self.reserved1 = reserved1
-        self.queue = queue
-        self.exchange = exchange
-        self.routingKey = routingKey
-        self.noWait = noWait
-        self.arguments = arguments
-    }
+  public init(
+    reserved1: UInt16 = 0,
+    queue: String,
+    exchange: String,
+    routingKey: String = "",
+    noWait: Bool = false,
+    arguments: Table = [:]
+  ) {
+    self.reserved1 = reserved1
+    self.queue = queue
+    self.exchange = exchange
+    self.routingKey = routingKey
+    self.noWait = noWait
+    self.arguments = arguments
+  }
 }
 
 public struct QueueUnbind: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var queue: String
-    public var exchange: String
-    public var routingKey: String
-    public var arguments: Table
+  public var reserved1: UInt16
+  public var queue: String
+  public var exchange: String
+  public var routingKey: String
+  public var arguments: Table
 
-    public init(
-        reserved1: UInt16 = 0,
-        queue: String,
-        exchange: String,
-        routingKey: String = "",
-        arguments: Table = [:]
-    ) {
-        self.reserved1 = reserved1
-        self.queue = queue
-        self.exchange = exchange
-        self.routingKey = routingKey
-        self.arguments = arguments
-    }
+  public init(
+    reserved1: UInt16 = 0,
+    queue: String,
+    exchange: String,
+    routingKey: String = "",
+    arguments: Table = [:]
+  ) {
+    self.reserved1 = reserved1
+    self.queue = queue
+    self.exchange = exchange
+    self.routingKey = routingKey
+    self.arguments = arguments
+  }
 }
 
 public struct QueuePurge: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var queue: String
-    public var noWait: Bool
+  public var reserved1: UInt16
+  public var queue: String
+  public var noWait: Bool
 
-    public init(reserved1: UInt16 = 0, queue: String, noWait: Bool = false) {
-        self.reserved1 = reserved1
-        self.queue = queue
-        self.noWait = noWait
-    }
+  public init(reserved1: UInt16 = 0, queue: String, noWait: Bool = false) {
+    self.reserved1 = reserved1
+    self.queue = queue
+    self.noWait = noWait
+  }
 }
 
 public struct QueuePurgeOk: Sendable, Equatable {
-    public var messageCount: UInt32
+  public var messageCount: UInt32
 
-    public init(messageCount: UInt32) {
-        self.messageCount = messageCount
-    }
+  public init(messageCount: UInt32) {
+    self.messageCount = messageCount
+  }
 }
 
 public struct QueueDelete: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var queue: String
-    public var ifUnused: Bool
-    public var ifEmpty: Bool
-    public var noWait: Bool
+  public var reserved1: UInt16
+  public var queue: String
+  public var ifUnused: Bool
+  public var ifEmpty: Bool
+  public var noWait: Bool
 
-    public init(
-        reserved1: UInt16 = 0,
-        queue: String,
-        ifUnused: Bool = false,
-        ifEmpty: Bool = false,
-        noWait: Bool = false
-    ) {
-        self.reserved1 = reserved1
-        self.queue = queue
-        self.ifUnused = ifUnused
-        self.ifEmpty = ifEmpty
-        self.noWait = noWait
-    }
+  public init(
+    reserved1: UInt16 = 0,
+    queue: String,
+    ifUnused: Bool = false,
+    ifEmpty: Bool = false,
+    noWait: Bool = false
+  ) {
+    self.reserved1 = reserved1
+    self.queue = queue
+    self.ifUnused = ifUnused
+    self.ifEmpty = ifEmpty
+    self.noWait = noWait
+  }
 }
 
 public struct QueueDeleteOk: Sendable, Equatable {
-    public var messageCount: UInt32
+  public var messageCount: UInt32
 
-    public init(messageCount: UInt32) {
-        self.messageCount = messageCount
-    }
+  public init(messageCount: UInt32) {
+    self.messageCount = messageCount
+  }
 }
 
 // Basic class payloads
 public struct BasicQos: Sendable, Equatable {
-    public var prefetchSize: UInt32
-    public var prefetchCount: UInt16
-    public var global: Bool
+  public var prefetchSize: UInt32
+  public var prefetchCount: UInt16
+  public var global: Bool
 
-    public init(prefetchSize: UInt32 = 0, prefetchCount: UInt16, global: Bool = false) {
-        self.prefetchSize = prefetchSize
-        self.prefetchCount = prefetchCount
-        self.global = global
-    }
+  public init(prefetchSize: UInt32 = 0, prefetchCount: UInt16, global: Bool = false) {
+    self.prefetchSize = prefetchSize
+    self.prefetchCount = prefetchCount
+    self.global = global
+  }
 }
 
 /// Consumer acknowledgement mode.
 public enum ConsumerAcknowledgementMode: Sendable {
-    /// Messages must be explicitly acknowledged via `ack`, `nack`, or `reject`.
-    case manual
-    /// Messages are automatically acknowledged upon delivery.
-    case automatic
+  /// Messages must be explicitly acknowledged via `ack`, `nack`, or `reject`.
+  case manual
+  /// Messages are automatically acknowledged upon delivery.
+  case automatic
 
-    /// Converts to the AMQP `no_ack` field value.
-    public var noAckFieldValue: Bool {
-        self == .automatic
-    }
+  /// Converts to the AMQP `no_ack` field value.
+  public var noAckFieldValue: Bool {
+    self == .automatic
+  }
 }
 
 public struct BasicConsume: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var queue: String
-    public var consumerTag: String
-    public var noLocal: Bool
-    public var noAck: Bool
-    public var exclusive: Bool
-    public var noWait: Bool
-    public var arguments: Table
+  public var reserved1: UInt16
+  public var queue: String
+  public var consumerTag: String
+  public var noLocal: Bool
+  public var noAck: Bool
+  public var exclusive: Bool
+  public var noWait: Bool
+  public var arguments: Table
 
-    public init(
-        reserved1: UInt16 = 0,
-        queue: String,
-        consumerTag: String = "",
-        noLocal: Bool = false,
-        noAck: Bool = false,
-        exclusive: Bool = false,
-        noWait: Bool = false,
-        arguments: Table = [:]
-    ) {
-        self.reserved1 = reserved1
-        self.queue = queue
-        self.consumerTag = consumerTag
-        self.noLocal = noLocal
-        self.noAck = noAck
-        self.exclusive = exclusive
-        self.noWait = noWait
-        self.arguments = arguments
-    }
+  public init(
+    reserved1: UInt16 = 0,
+    queue: String,
+    consumerTag: String = "",
+    noLocal: Bool = false,
+    noAck: Bool = false,
+    exclusive: Bool = false,
+    noWait: Bool = false,
+    arguments: Table = [:]
+  ) {
+    self.reserved1 = reserved1
+    self.queue = queue
+    self.consumerTag = consumerTag
+    self.noLocal = noLocal
+    self.noAck = noAck
+    self.exclusive = exclusive
+    self.noWait = noWait
+    self.arguments = arguments
+  }
 }
 
 public struct BasicConsumeOk: Sendable, Equatable {
-    public var consumerTag: String
+  public var consumerTag: String
 
-    public init(consumerTag: String) {
-        self.consumerTag = consumerTag
-    }
+  public init(consumerTag: String) {
+    self.consumerTag = consumerTag
+  }
 }
 
 public struct BasicCancel: Sendable, Equatable {
-    public var consumerTag: String
-    public var noWait: Bool
+  public var consumerTag: String
+  public var noWait: Bool
 
-    public init(consumerTag: String, noWait: Bool = false) {
-        self.consumerTag = consumerTag
-        self.noWait = noWait
-    }
+  public init(consumerTag: String, noWait: Bool = false) {
+    self.consumerTag = consumerTag
+    self.noWait = noWait
+  }
 }
 
 public struct BasicCancelOk: Sendable, Equatable {
-    public var consumerTag: String
+  public var consumerTag: String
 
-    public init(consumerTag: String) {
-        self.consumerTag = consumerTag
-    }
+  public init(consumerTag: String) {
+    self.consumerTag = consumerTag
+  }
 }
 
 public struct BasicPublish: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var exchange: String
-    public var routingKey: String
-    public var mandatory: Bool
-    public var immediate: Bool
+  public var reserved1: UInt16
+  public var exchange: String
+  public var routingKey: String
+  public var mandatory: Bool
+  public var immediate: Bool
 
-    public init(
-        reserved1: UInt16 = 0,
-        exchange: String = "",
-        routingKey: String,
-        mandatory: Bool = false,
-        immediate: Bool = false
-    ) {
-        self.reserved1 = reserved1
-        self.exchange = exchange
-        self.routingKey = routingKey
-        self.mandatory = mandatory
-        self.immediate = immediate
-    }
+  public init(
+    reserved1: UInt16 = 0,
+    exchange: String = "",
+    routingKey: String,
+    mandatory: Bool = false,
+    immediate: Bool = false
+  ) {
+    self.reserved1 = reserved1
+    self.exchange = exchange
+    self.routingKey = routingKey
+    self.mandatory = mandatory
+    self.immediate = immediate
+  }
 }
 
 public struct BasicReturn: Sendable, Equatable {
-    public var replyCode: UInt16
-    public var replyText: String
-    public var exchange: String
-    public var routingKey: String
+  public var replyCode: UInt16
+  public var replyText: String
+  public var exchange: String
+  public var routingKey: String
 
-    public init(replyCode: UInt16, replyText: String, exchange: String, routingKey: String) {
-        self.replyCode = replyCode
-        self.replyText = replyText
-        self.exchange = exchange
-        self.routingKey = routingKey
-    }
+  public init(replyCode: UInt16, replyText: String, exchange: String, routingKey: String) {
+    self.replyCode = replyCode
+    self.replyText = replyText
+    self.exchange = exchange
+    self.routingKey = routingKey
+  }
 }
 
 public struct BasicDeliver: Sendable, Equatable {
-    public var consumerTag: String
-    public var deliveryTag: UInt64
-    public var redelivered: Bool
-    public var exchange: String
-    public var routingKey: String
+  public var consumerTag: String
+  public var deliveryTag: UInt64
+  public var redelivered: Bool
+  public var exchange: String
+  public var routingKey: String
 
-    public init(
-        consumerTag: String,
-        deliveryTag: UInt64,
-        redelivered: Bool,
-        exchange: String,
-        routingKey: String
-    ) {
-        self.consumerTag = consumerTag
-        self.deliveryTag = deliveryTag
-        self.redelivered = redelivered
-        self.exchange = exchange
-        self.routingKey = routingKey
-    }
+  public init(
+    consumerTag: String,
+    deliveryTag: UInt64,
+    redelivered: Bool,
+    exchange: String,
+    routingKey: String
+  ) {
+    self.consumerTag = consumerTag
+    self.deliveryTag = deliveryTag
+    self.redelivered = redelivered
+    self.exchange = exchange
+    self.routingKey = routingKey
+  }
 }
 
 public struct BasicGet: Sendable, Equatable {
-    public var reserved1: UInt16
-    public var queue: String
-    public var noAck: Bool
+  public var reserved1: UInt16
+  public var queue: String
+  public var noAck: Bool
 
-    public init(reserved1: UInt16 = 0, queue: String, noAck: Bool = false) {
-        self.reserved1 = reserved1
-        self.queue = queue
-        self.noAck = noAck
-    }
+  public init(reserved1: UInt16 = 0, queue: String, noAck: Bool = false) {
+    self.reserved1 = reserved1
+    self.queue = queue
+    self.noAck = noAck
+  }
 }
 
 public struct BasicGetOk: Sendable, Equatable {
-    public var deliveryTag: UInt64
-    public var redelivered: Bool
-    public var exchange: String
-    public var routingKey: String
-    public var messageCount: UInt32
+  public var deliveryTag: UInt64
+  public var redelivered: Bool
+  public var exchange: String
+  public var routingKey: String
+  public var messageCount: UInt32
 
-    public init(
-        deliveryTag: UInt64,
-        redelivered: Bool,
-        exchange: String,
-        routingKey: String,
-        messageCount: UInt32
-    ) {
-        self.deliveryTag = deliveryTag
-        self.redelivered = redelivered
-        self.exchange = exchange
-        self.routingKey = routingKey
-        self.messageCount = messageCount
-    }
+  public init(
+    deliveryTag: UInt64,
+    redelivered: Bool,
+    exchange: String,
+    routingKey: String,
+    messageCount: UInt32
+  ) {
+    self.deliveryTag = deliveryTag
+    self.redelivered = redelivered
+    self.exchange = exchange
+    self.routingKey = routingKey
+    self.messageCount = messageCount
+  }
 }
 
 public struct BasicGetEmpty: Sendable, Equatable {
-    public var reserved1: String
+  public var reserved1: String
 
-    public init(reserved1: String = "") {
-        self.reserved1 = reserved1
-    }
+  public init(reserved1: String = "") {
+    self.reserved1 = reserved1
+  }
 }
 
 public struct BasicAck: Sendable, Equatable {
-    public var deliveryTag: UInt64
-    public var multiple: Bool
+  public var deliveryTag: UInt64
+  public var multiple: Bool
 
-    public init(deliveryTag: UInt64, multiple: Bool = false) {
-        self.deliveryTag = deliveryTag
-        self.multiple = multiple
-    }
+  public init(deliveryTag: UInt64, multiple: Bool = false) {
+    self.deliveryTag = deliveryTag
+    self.multiple = multiple
+  }
 }
 
 public struct BasicReject: Sendable, Equatable {
-    public var deliveryTag: UInt64
-    public var requeue: Bool
+  public var deliveryTag: UInt64
+  public var requeue: Bool
 
-    public init(deliveryTag: UInt64, requeue: Bool = true) {
-        self.deliveryTag = deliveryTag
-        self.requeue = requeue
-    }
+  public init(deliveryTag: UInt64, requeue: Bool = true) {
+    self.deliveryTag = deliveryTag
+    self.requeue = requeue
+  }
 }
 
 public struct BasicRecoverAsync: Sendable, Equatable {
-    public var requeue: Bool
+  public var requeue: Bool
 
-    public init(requeue: Bool = true) {
-        self.requeue = requeue
-    }
+  public init(requeue: Bool = true) {
+    self.requeue = requeue
+  }
 }
 
 public struct BasicRecover: Sendable, Equatable {
-    public var requeue: Bool
+  public var requeue: Bool
 
-    public init(requeue: Bool = true) {
-        self.requeue = requeue
-    }
+  public init(requeue: Bool = true) {
+    self.requeue = requeue
+  }
 }
 
 public struct BasicNack: Sendable, Equatable {
-    public var deliveryTag: UInt64
-    public var multiple: Bool
-    public var requeue: Bool
+  public var deliveryTag: UInt64
+  public var multiple: Bool
+  public var requeue: Bool
 
-    public init(deliveryTag: UInt64, multiple: Bool = false, requeue: Bool = true) {
-        self.deliveryTag = deliveryTag
-        self.multiple = multiple
-        self.requeue = requeue
-    }
+  public init(deliveryTag: UInt64, multiple: Bool = false, requeue: Bool = true) {
+    self.deliveryTag = deliveryTag
+    self.multiple = multiple
+    self.requeue = requeue
+  }
 }
 
 // Confirm class payloads
 public struct ConfirmSelect: Sendable, Equatable {
-    public var noWait: Bool
+  public var noWait: Bool
 
-    public init(noWait: Bool = false) {
-        self.noWait = noWait
-    }
+  public init(noWait: Bool = false) {
+    self.noWait = noWait
+  }
 }

--- a/Sources/AMQPProtocol/FrameCodec.swift
+++ b/Sources/AMQPProtocol/FrameCodec.swift
@@ -11,839 +11,873 @@ import Foundation
 
 /// Encodes and decodes AMQP frames
 public struct FrameCodec: Sendable {
-    /// Maximum frame size for this codec
-    public let maxFrameSize: UInt32
+  /// Maximum frame size for this codec
+  public let maxFrameSize: UInt32
 
-    public init(maxFrameSize: UInt32 = FrameDefaults.maxSize) {
-        self.maxFrameSize = maxFrameSize
+  public init(maxFrameSize: UInt32 = FrameDefaults.maxSize) {
+    self.maxFrameSize = maxFrameSize
+  }
+
+  // MARK: - Encoding
+
+  /// Encode a frame to wire format
+  public func encode(_ frame: Frame) throws -> Data {
+    var encoder = WireEncoder()
+
+    switch frame {
+    case .method(let channelID, let method):
+      try encodeMethodFrame(channelID: channelID, method: method, to: &encoder)
+
+    case .header(let channelID, let classID, let bodySize, let properties):
+      try encodeHeaderFrame(
+        channelID: channelID, classID: classID, bodySize: bodySize,
+        properties: properties, to: &encoder)
+
+    case .body(let channelID, let payload):
+      try encodeBodyFrame(channelID: channelID, payload: payload, to: &encoder)
+
+    case .heartbeat:
+      encodeHeartbeatFrame(to: &encoder)
     }
 
-    // MARK: - Encoding
+    return encoder.encodedData
+  }
 
-    /// Encode a frame to wire format
-    public func encode(_ frame: Frame) throws -> Data {
-        var encoder = WireEncoder()
+  /// Encode multiple body frames for large payloads
+  public func encodeBodyFrames(channelID: UInt16, payload: Data) throws -> [Data] {
+    let maxBodySize = Int(maxFrameSize) - FrameDefaults.headerSize - 1  // -1 for frame end
+    var frames = [Data]()
 
-        switch frame {
-        case .method(let channelID, let method):
-            try encodeMethodFrame(channelID: channelID, method: method, to: &encoder)
+    var offset = 0
+    while offset < payload.count {
+      let remaining = payload.count - offset
+      let chunkSize = min(remaining, maxBodySize)
+      let chunk = payload[offset..<offset + chunkSize]
 
-        case .header(let channelID, let classID, let bodySize, let properties):
-            try encodeHeaderFrame(channelID: channelID, classID: classID, bodySize: bodySize,
-                                  properties: properties, to: &encoder)
+      var encoder = WireEncoder()
+      encoder.writeUInt8(FrameType.body.rawValue)
+      encoder.writeUInt16(channelID)
+      encoder.writeUInt32(UInt32(chunkSize))
+      encoder.writeBytes(Data(chunk))
+      encoder.writeUInt8(frameEnd)
 
-        case .body(let channelID, let payload):
-            try encodeBodyFrame(channelID: channelID, payload: payload, to: &encoder)
-
-        case .heartbeat:
-            encodeHeartbeatFrame(to: &encoder)
-        }
-
-        return encoder.encodedData
+      frames.append(encoder.encodedData)
+      offset += chunkSize
     }
 
-    /// Encode multiple body frames for large payloads
-    public func encodeBodyFrames(channelID: UInt16, payload: Data) throws -> [Data] {
-        let maxBodySize = Int(maxFrameSize) - FrameDefaults.headerSize - 1  // -1 for frame end
-        var frames = [Data]()
+    return frames
+  }
 
-        var offset = 0
-        while offset < payload.count {
-            let remaining = payload.count - offset
-            let chunkSize = min(remaining, maxBodySize)
-            let chunk = payload[offset..<offset + chunkSize]
+  private func encodeMethodFrame(channelID: UInt16, method: Method, to encoder: inout WireEncoder)
+    throws
+  {
+    var payloadEncoder = WireEncoder()
+    payloadEncoder.writeUInt16(method.methodID.classID)
+    payloadEncoder.writeUInt16(method.methodID.methodID)
+    try encodeMethodPayload(method, to: &payloadEncoder)
 
-            var encoder = WireEncoder()
-            encoder.writeUInt8(FrameType.body.rawValue)
-            encoder.writeUInt16(channelID)
-            encoder.writeUInt32(UInt32(chunkSize))
-            encoder.writeBytes(Data(chunk))
-            encoder.writeUInt8(frameEnd)
-
-            frames.append(encoder.encodedData)
-            offset += chunkSize
-        }
-
-        return frames
+    let payload = payloadEncoder.encodedData
+    guard payload.count <= Int(maxFrameSize) - FrameDefaults.headerSize - 1 else {
+      throw WireFormatError.frameTooLarge(size: UInt32(payload.count), maxSize: maxFrameSize)
     }
 
-    private func encodeMethodFrame(channelID: UInt16, method: Method, to encoder: inout WireEncoder) throws {
-        var payloadEncoder = WireEncoder()
-        payloadEncoder.writeUInt16(method.methodID.classID)
-        payloadEncoder.writeUInt16(method.methodID.methodID)
-        try encodeMethodPayload(method, to: &payloadEncoder)
+    encoder.writeUInt8(FrameType.method.rawValue)
+    encoder.writeUInt16(channelID)
+    encoder.writeUInt32(UInt32(payload.count))
+    encoder.writeBytes(payload)
+    encoder.writeUInt8(frameEnd)
+  }
 
-        let payload = payloadEncoder.encodedData
-        guard payload.count <= Int(maxFrameSize) - FrameDefaults.headerSize - 1 else {
-            throw WireFormatError.frameTooLarge(size: UInt32(payload.count), maxSize: maxFrameSize)
-        }
+  private func encodeHeaderFrame(
+    channelID: UInt16,
+    classID: UInt16,
+    bodySize: UInt64,
+    properties: BasicProperties,
+    to encoder: inout WireEncoder
+  ) throws {
+    var payloadEncoder = WireEncoder()
+    payloadEncoder.writeUInt16(classID)
+    payloadEncoder.writeUInt16(0)  // weight (reserved)
+    payloadEncoder.writeUInt64(bodySize)
+    try properties.encode(to: &payloadEncoder)
 
-        encoder.writeUInt8(FrameType.method.rawValue)
-        encoder.writeUInt16(channelID)
-        encoder.writeUInt32(UInt32(payload.count))
-        encoder.writeBytes(payload)
-        encoder.writeUInt8(frameEnd)
+    let payload = payloadEncoder.encodedData
+    guard payload.count <= Int(maxFrameSize) - FrameDefaults.headerSize - 1 else {
+      throw WireFormatError.frameTooLarge(size: UInt32(payload.count), maxSize: maxFrameSize)
     }
 
-    private func encodeHeaderFrame(
-        channelID: UInt16,
-        classID: UInt16,
-        bodySize: UInt64,
-        properties: BasicProperties,
-        to encoder: inout WireEncoder
-    ) throws {
-        var payloadEncoder = WireEncoder()
-        payloadEncoder.writeUInt16(classID)
-        payloadEncoder.writeUInt16(0)  // weight (reserved)
-        payloadEncoder.writeUInt64(bodySize)
-        try properties.encode(to: &payloadEncoder)
+    encoder.writeUInt8(FrameType.header.rawValue)
+    encoder.writeUInt16(channelID)
+    encoder.writeUInt32(UInt32(payload.count))
+    encoder.writeBytes(payload)
+    encoder.writeUInt8(frameEnd)
+  }
 
-        let payload = payloadEncoder.encodedData
-        guard payload.count <= Int(maxFrameSize) - FrameDefaults.headerSize - 1 else {
-            throw WireFormatError.frameTooLarge(size: UInt32(payload.count), maxSize: maxFrameSize)
-        }
-
-        encoder.writeUInt8(FrameType.header.rawValue)
-        encoder.writeUInt16(channelID)
-        encoder.writeUInt32(UInt32(payload.count))
-        encoder.writeBytes(payload)
-        encoder.writeUInt8(frameEnd)
+  private func encodeBodyFrame(channelID: UInt16, payload: Data, to encoder: inout WireEncoder)
+    throws
+  {
+    guard payload.count <= Int(maxFrameSize) - FrameDefaults.headerSize - 1 else {
+      throw WireFormatError.frameTooLarge(size: UInt32(payload.count), maxSize: maxFrameSize)
     }
 
-    private func encodeBodyFrame(channelID: UInt16, payload: Data, to encoder: inout WireEncoder) throws {
-        guard payload.count <= Int(maxFrameSize) - FrameDefaults.headerSize - 1 else {
-            throw WireFormatError.frameTooLarge(size: UInt32(payload.count), maxSize: maxFrameSize)
-        }
+    encoder.writeUInt8(FrameType.body.rawValue)
+    encoder.writeUInt16(channelID)
+    encoder.writeUInt32(UInt32(payload.count))
+    encoder.writeBytes(payload)
+    encoder.writeUInt8(frameEnd)
+  }
 
-        encoder.writeUInt8(FrameType.body.rawValue)
-        encoder.writeUInt16(channelID)
-        encoder.writeUInt32(UInt32(payload.count))
-        encoder.writeBytes(payload)
-        encoder.writeUInt8(frameEnd)
+  private func encodeHeartbeatFrame(to encoder: inout WireEncoder) {
+    encoder.writeUInt8(FrameType.heartbeat.rawValue)
+    encoder.writeUInt16(0)  // channel 0
+    encoder.writeUInt32(0)  // no payload
+    encoder.writeUInt8(frameEnd)
+  }
+
+  // MARK: - Decoding
+
+  /// Decode a frame from wire format
+  /// Returns nil if insufficient data (need more bytes)
+  public func decode(from buffer: inout Data) throws -> Frame? {
+    guard buffer.count >= FrameDefaults.headerSize + 1 else {
+      return nil
     }
 
-    private func encodeHeartbeatFrame(to encoder: inout WireEncoder) {
-        encoder.writeUInt8(FrameType.heartbeat.rawValue)
-        encoder.writeUInt16(0)  // channel 0
-        encoder.writeUInt32(0)  // no payload
-        encoder.writeUInt8(frameEnd)
+    var decoder = buffer.wireDecoder()
+    let frameTypeRaw = try decoder.readUInt8()
+    let channelID = try decoder.readUInt16()
+    let payloadSize = try decoder.readUInt32()
+
+    let maxPayload = maxFrameSize - UInt32(FrameDefaults.headerSize) - 1
+    guard payloadSize <= maxPayload else {
+      throw WireFormatError.frameTooLarge(size: payloadSize, maxSize: maxFrameSize)
     }
 
-    // MARK: - Decoding
-
-    /// Decode a frame from wire format
-    /// Returns nil if insufficient data (need more bytes)
-    public func decode(from buffer: inout Data) throws -> Frame? {
-        guard buffer.count >= FrameDefaults.headerSize + 1 else {
-            return nil
-        }
-
-        var decoder = buffer.wireDecoder()
-        let frameTypeRaw = try decoder.readUInt8()
-        let channelID = try decoder.readUInt16()
-        let payloadSize = try decoder.readUInt32()
-
-        let maxPayload = maxFrameSize - UInt32(FrameDefaults.headerSize) - 1
-        guard payloadSize <= maxPayload else {
-            throw WireFormatError.frameTooLarge(size: payloadSize, maxSize: maxFrameSize)
-        }
-
-        let totalSize = FrameDefaults.headerSize + Int(payloadSize) + 1
-        guard buffer.count >= totalSize else {
-            return nil
-        }
-
-        let payload = try decoder.readBytes(Int(payloadSize))
-        let actualFrameEnd = try decoder.readUInt8()
-        guard actualFrameEnd == frameEnd else {
-            throw WireFormatError.invalidFrameEnd(expected: frameEnd, actual: actualFrameEnd)
-        }
-
-        buffer.removeFirst(totalSize)
-
-        guard let frameType = FrameType(rawValue: frameTypeRaw) else {
-            throw WireFormatError.unknownFrameType(frameTypeRaw)
-        }
-
-        switch frameType {
-        case .method:
-            let method = try decodeMethodPayload(payload)
-            return .method(channelID: channelID, method: method)
-
-        case .header:
-            var payloadDecoder = payload.wireDecoder()
-            let classID = try payloadDecoder.readUInt16()
-            _ = try payloadDecoder.readUInt16()  // weight (reserved)
-            let bodySize = try payloadDecoder.readUInt64()
-            let properties = try BasicProperties.decode(from: &payloadDecoder)
-            return .header(channelID: channelID, classID: classID, bodySize: bodySize, properties: properties)
-
-        case .body:
-            return .body(channelID: channelID, payload: payload)
-
-        case .heartbeat:
-            return .heartbeat
-        }
+    let totalSize = FrameDefaults.headerSize + Int(payloadSize) + 1
+    guard buffer.count >= totalSize else {
+      return nil
     }
 
-    /// Check if buffer contains the protocol header
-    public static func isProtocolHeader(_ data: Data) -> Bool {
-        data.count >= 8 && data.prefix(4) == Data([0x41, 0x4D, 0x51, 0x50])  // "AMQP"
+    let payload = try decoder.readBytes(Int(payloadSize))
+    let actualFrameEnd = try decoder.readUInt8()
+    guard actualFrameEnd == frameEnd else {
+      throw WireFormatError.invalidFrameEnd(expected: frameEnd, actual: actualFrameEnd)
     }
 
-    /// Decode protocol header
-    public static func decodeProtocolHeader(_ data: Data) throws -> (major: UInt8, minor: UInt8, revision: UInt8)? {
-        guard data.count >= 8 else { return nil }
-        guard data.prefix(4) == Data([0x41, 0x4D, 0x51, 0x50]) else { return nil }
-        return (data[5], data[6], data[7])
+    buffer.removeFirst(totalSize)
+
+    guard let frameType = FrameType(rawValue: frameTypeRaw) else {
+      throw WireFormatError.unknownFrameType(frameTypeRaw)
     }
 
-    // MARK: - Method Payload Encoding
+    switch frameType {
+    case .method:
+      let method = try decodeMethodPayload(payload)
+      return .method(channelID: channelID, method: method)
 
-    private func encodeMethodPayload(_ method: Method, to encoder: inout WireEncoder) throws {
-        switch method {
-        // Connection class
-        case .connectionStart(let m):
-            encoder.writeUInt8(m.versionMajor)
-            encoder.writeUInt8(m.versionMinor)
-            try encodeTable(m.serverProperties, to: &encoder)
-            encoder.writeLongString(m.mechanisms)
-            encoder.writeLongString(m.locales)
+    case .header:
+      var payloadDecoder = payload.wireDecoder()
+      let classID = try payloadDecoder.readUInt16()
+      _ = try payloadDecoder.readUInt16()  // weight (reserved)
+      let bodySize = try payloadDecoder.readUInt64()
+      let properties = try BasicProperties.decode(from: &payloadDecoder)
+      return .header(
+        channelID: channelID, classID: classID, bodySize: bodySize, properties: properties)
 
-        case .connectionStartOk(let m):
-            try encodeTable(m.clientProperties, to: &encoder)
-            try encoder.writeShortString(m.mechanism)
-            encoder.writeLongString(m.response)
-            try encoder.writeShortString(m.locale)
+    case .body:
+      return .body(channelID: channelID, payload: payload)
 
-        case .connectionSecure(let m):
-            encoder.writeLongString(m.challenge)
-
-        case .connectionSecureOk(let m):
-            encoder.writeLongString(m.response)
-
-        case .connectionTune(let m):
-            encoder.writeUInt16(m.channelMax)
-            encoder.writeUInt32(m.frameMax)
-            encoder.writeUInt16(m.heartbeat)
-
-        case .connectionTuneOk(let m):
-            encoder.writeUInt16(m.channelMax)
-            encoder.writeUInt32(m.frameMax)
-            encoder.writeUInt16(m.heartbeat)
-
-        case .connectionOpen(let m):
-            try encoder.writeShortString(m.virtualHost)
-            try encoder.writeShortString(m.reserved1)
-            encoder.writeBits([m.reserved2])
-
-        case .connectionOpenOk(let m):
-            try encoder.writeShortString(m.reserved1)
-
-        case .connectionClose(let m):
-            encoder.writeUInt16(m.replyCode)
-            try encoder.writeShortString(m.replyText)
-            encoder.writeUInt16(m.classId)
-            encoder.writeUInt16(m.methodId)
-
-        case .connectionCloseOk:
-            break  // no payload
-
-        case .connectionBlocked(let m):
-            try encoder.writeShortString(m.reason)
-
-        case .connectionUnblocked:
-            break  // no payload
-
-        // Channel class
-        case .channelOpen(let m):
-            try encoder.writeShortString(m.reserved1)
-
-        case .channelOpenOk(let m):
-            encoder.writeLongString(m.reserved1)
-
-        case .channelFlow(let m):
-            encoder.writeBits([m.active])
-
-        case .channelFlowOk(let m):
-            encoder.writeBits([m.active])
-
-        case .channelClose(let m):
-            encoder.writeUInt16(m.replyCode)
-            try encoder.writeShortString(m.replyText)
-            encoder.writeUInt16(m.classId)
-            encoder.writeUInt16(m.methodId)
-
-        case .channelCloseOk:
-            break  // no payload
-
-        // Exchange class
-        case .exchangeDeclare(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.exchange)
-            try encoder.writeShortString(m.type)
-            encoder.writeBits([m.passive, m.durable, m.autoDelete, m.internal, m.noWait])
-            try encodeTable(m.arguments, to: &encoder)
-
-        case .exchangeDeclareOk:
-            break
-
-        case .exchangeDelete(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.exchange)
-            encoder.writeBits([m.ifUnused, m.noWait])
-
-        case .exchangeDeleteOk:
-            break
-
-        case .exchangeBind(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.destination)
-            try encoder.writeShortString(m.source)
-            try encoder.writeShortString(m.routingKey)
-            encoder.writeBits([m.noWait])
-            try encodeTable(m.arguments, to: &encoder)
-
-        case .exchangeBindOk:
-            break
-
-        case .exchangeUnbind(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.destination)
-            try encoder.writeShortString(m.source)
-            try encoder.writeShortString(m.routingKey)
-            encoder.writeBits([m.noWait])
-            try encodeTable(m.arguments, to: &encoder)
-
-        case .exchangeUnbindOk:
-            break
-
-        // Queue class
-        case .queueDeclare(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.queue)
-            encoder.writeBits([m.passive, m.durable, m.exclusive, m.autoDelete, m.noWait])
-            try encodeTable(m.arguments, to: &encoder)
-
-        case .queueDeclareOk(let m):
-            try encoder.writeShortString(m.queue)
-            encoder.writeUInt32(m.messageCount)
-            encoder.writeUInt32(m.consumerCount)
-
-        case .queueBind(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.queue)
-            try encoder.writeShortString(m.exchange)
-            try encoder.writeShortString(m.routingKey)
-            encoder.writeBits([m.noWait])
-            try encodeTable(m.arguments, to: &encoder)
-
-        case .queueBindOk:
-            break
-
-        case .queueUnbind(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.queue)
-            try encoder.writeShortString(m.exchange)
-            try encoder.writeShortString(m.routingKey)
-            try encodeTable(m.arguments, to: &encoder)
-
-        case .queueUnbindOk:
-            break
-
-        case .queuePurge(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.queue)
-            encoder.writeBits([m.noWait])
-
-        case .queuePurgeOk(let m):
-            encoder.writeUInt32(m.messageCount)
-
-        case .queueDelete(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.queue)
-            encoder.writeBits([m.ifUnused, m.ifEmpty, m.noWait])
-
-        case .queueDeleteOk(let m):
-            encoder.writeUInt32(m.messageCount)
-
-        // Basic class
-        case .basicQos(let m):
-            encoder.writeUInt32(m.prefetchSize)
-            encoder.writeUInt16(m.prefetchCount)
-            encoder.writeBits([m.global])
-
-        case .basicQosOk:
-            break
-
-        case .basicConsume(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.queue)
-            try encoder.writeShortString(m.consumerTag)
-            encoder.writeBits([m.noLocal, m.noAck, m.exclusive, m.noWait])
-            try encodeTable(m.arguments, to: &encoder)
-
-        case .basicConsumeOk(let m):
-            try encoder.writeShortString(m.consumerTag)
-
-        case .basicCancel(let m):
-            try encoder.writeShortString(m.consumerTag)
-            encoder.writeBits([m.noWait])
-
-        case .basicCancelOk(let m):
-            try encoder.writeShortString(m.consumerTag)
-
-        case .basicPublish(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.exchange)
-            try encoder.writeShortString(m.routingKey)
-            encoder.writeBits([m.mandatory, m.immediate])
-
-        case .basicReturn(let m):
-            encoder.writeUInt16(m.replyCode)
-            try encoder.writeShortString(m.replyText)
-            try encoder.writeShortString(m.exchange)
-            try encoder.writeShortString(m.routingKey)
-
-        case .basicDeliver(let m):
-            try encoder.writeShortString(m.consumerTag)
-            encoder.writeUInt64(m.deliveryTag)
-            encoder.writeBits([m.redelivered])
-            try encoder.writeShortString(m.exchange)
-            try encoder.writeShortString(m.routingKey)
-
-        case .basicGet(let m):
-            encoder.writeUInt16(m.reserved1)
-            try encoder.writeShortString(m.queue)
-            encoder.writeBits([m.noAck])
-
-        case .basicGetOk(let m):
-            encoder.writeUInt64(m.deliveryTag)
-            encoder.writeBits([m.redelivered])
-            try encoder.writeShortString(m.exchange)
-            try encoder.writeShortString(m.routingKey)
-            encoder.writeUInt32(m.messageCount)
-
-        case .basicGetEmpty(let m):
-            try encoder.writeShortString(m.reserved1)
-
-        case .basicAck(let m):
-            encoder.writeUInt64(m.deliveryTag)
-            encoder.writeBits([m.multiple])
-
-        case .basicReject(let m):
-            encoder.writeUInt64(m.deliveryTag)
-            encoder.writeBits([m.requeue])
-
-        case .basicRecoverAsync(let m):
-            encoder.writeBits([m.requeue])
-
-        case .basicRecover(let m):
-            encoder.writeBits([m.requeue])
-
-        case .basicRecoverOk:
-            break
-
-        case .basicNack(let m):
-            encoder.writeUInt64(m.deliveryTag)
-            encoder.writeBits([m.multiple, m.requeue])
-
-        // Tx class
-        case .txSelect, .txSelectOk, .txCommit, .txCommitOk, .txRollback, .txRollbackOk:
-            break  // no payload
-
-        // Confirm class
-        case .confirmSelect(let m):
-            encoder.writeBits([m.noWait])
-
-        case .confirmSelectOk:
-            break
-        }
+    case .heartbeat:
+      return .heartbeat
     }
+  }
 
-    // MARK: - Method Payload Decoding
+  /// Check if buffer contains the protocol header
+  public static func isProtocolHeader(_ data: Data) -> Bool {
+    data.count >= 8 && data.prefix(4) == Data([0x41, 0x4D, 0x51, 0x50])  // "AMQP"
+  }
 
-    public func decodeMethod(from data: Data) throws -> Method {
-        try decodeMethodPayload(data)
+  /// Decode protocol header
+  public static func decodeProtocolHeader(_ data: Data) throws -> (
+    major: UInt8, minor: UInt8, revision: UInt8
+  )? {
+    guard data.count >= 8 else { return nil }
+    guard data.prefix(4) == Data([0x41, 0x4D, 0x51, 0x50]) else { return nil }
+    return (data[5], data[6], data[7])
+  }
+
+  // MARK: - Method Payload Encoding
+
+  private func encodeMethodPayload(_ method: Method, to encoder: inout WireEncoder) throws {
+    switch method {
+    // Connection class
+    case .connectionStart(let m):
+      encoder.writeUInt8(m.versionMajor)
+      encoder.writeUInt8(m.versionMinor)
+      try encodeTable(m.serverProperties, to: &encoder)
+      encoder.writeLongString(m.mechanisms)
+      encoder.writeLongString(m.locales)
+
+    case .connectionStartOk(let m):
+      try encodeTable(m.clientProperties, to: &encoder)
+      try encoder.writeShortString(m.mechanism)
+      encoder.writeLongString(m.response)
+      try encoder.writeShortString(m.locale)
+
+    case .connectionSecure(let m):
+      encoder.writeLongString(m.challenge)
+
+    case .connectionSecureOk(let m):
+      encoder.writeLongString(m.response)
+
+    case .connectionTune(let m):
+      encoder.writeUInt16(m.channelMax)
+      encoder.writeUInt32(m.frameMax)
+      encoder.writeUInt16(m.heartbeat)
+
+    case .connectionTuneOk(let m):
+      encoder.writeUInt16(m.channelMax)
+      encoder.writeUInt32(m.frameMax)
+      encoder.writeUInt16(m.heartbeat)
+
+    case .connectionOpen(let m):
+      try encoder.writeShortString(m.virtualHost)
+      try encoder.writeShortString(m.reserved1)
+      encoder.writeBits([m.reserved2])
+
+    case .connectionOpenOk(let m):
+      try encoder.writeShortString(m.reserved1)
+
+    case .connectionClose(let m):
+      encoder.writeUInt16(m.replyCode)
+      try encoder.writeShortString(m.replyText)
+      encoder.writeUInt16(m.classId)
+      encoder.writeUInt16(m.methodId)
+
+    case .connectionCloseOk:
+      break  // no payload
+
+    case .connectionBlocked(let m):
+      try encoder.writeShortString(m.reason)
+
+    case .connectionUnblocked:
+      break  // no payload
+
+    // Channel class
+    case .channelOpen(let m):
+      try encoder.writeShortString(m.reserved1)
+
+    case .channelOpenOk(let m):
+      encoder.writeLongString(m.reserved1)
+
+    case .channelFlow(let m):
+      encoder.writeBits([m.active])
+
+    case .channelFlowOk(let m):
+      encoder.writeBits([m.active])
+
+    case .channelClose(let m):
+      encoder.writeUInt16(m.replyCode)
+      try encoder.writeShortString(m.replyText)
+      encoder.writeUInt16(m.classId)
+      encoder.writeUInt16(m.methodId)
+
+    case .channelCloseOk:
+      break  // no payload
+
+    // Exchange class
+    case .exchangeDeclare(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.exchange)
+      try encoder.writeShortString(m.type)
+      encoder.writeBits([m.passive, m.durable, m.autoDelete, m.internal, m.noWait])
+      try encodeTable(m.arguments, to: &encoder)
+
+    case .exchangeDeclareOk:
+      break
+
+    case .exchangeDelete(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.exchange)
+      encoder.writeBits([m.ifUnused, m.noWait])
+
+    case .exchangeDeleteOk:
+      break
+
+    case .exchangeBind(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.destination)
+      try encoder.writeShortString(m.source)
+      try encoder.writeShortString(m.routingKey)
+      encoder.writeBits([m.noWait])
+      try encodeTable(m.arguments, to: &encoder)
+
+    case .exchangeBindOk:
+      break
+
+    case .exchangeUnbind(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.destination)
+      try encoder.writeShortString(m.source)
+      try encoder.writeShortString(m.routingKey)
+      encoder.writeBits([m.noWait])
+      try encodeTable(m.arguments, to: &encoder)
+
+    case .exchangeUnbindOk:
+      break
+
+    // Queue class
+    case .queueDeclare(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.queue)
+      encoder.writeBits([m.passive, m.durable, m.exclusive, m.autoDelete, m.noWait])
+      try encodeTable(m.arguments, to: &encoder)
+
+    case .queueDeclareOk(let m):
+      try encoder.writeShortString(m.queue)
+      encoder.writeUInt32(m.messageCount)
+      encoder.writeUInt32(m.consumerCount)
+
+    case .queueBind(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.queue)
+      try encoder.writeShortString(m.exchange)
+      try encoder.writeShortString(m.routingKey)
+      encoder.writeBits([m.noWait])
+      try encodeTable(m.arguments, to: &encoder)
+
+    case .queueBindOk:
+      break
+
+    case .queueUnbind(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.queue)
+      try encoder.writeShortString(m.exchange)
+      try encoder.writeShortString(m.routingKey)
+      try encodeTable(m.arguments, to: &encoder)
+
+    case .queueUnbindOk:
+      break
+
+    case .queuePurge(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.queue)
+      encoder.writeBits([m.noWait])
+
+    case .queuePurgeOk(let m):
+      encoder.writeUInt32(m.messageCount)
+
+    case .queueDelete(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.queue)
+      encoder.writeBits([m.ifUnused, m.ifEmpty, m.noWait])
+
+    case .queueDeleteOk(let m):
+      encoder.writeUInt32(m.messageCount)
+
+    // Basic class
+    case .basicQos(let m):
+      encoder.writeUInt32(m.prefetchSize)
+      encoder.writeUInt16(m.prefetchCount)
+      encoder.writeBits([m.global])
+
+    case .basicQosOk:
+      break
+
+    case .basicConsume(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.queue)
+      try encoder.writeShortString(m.consumerTag)
+      encoder.writeBits([m.noLocal, m.noAck, m.exclusive, m.noWait])
+      try encodeTable(m.arguments, to: &encoder)
+
+    case .basicConsumeOk(let m):
+      try encoder.writeShortString(m.consumerTag)
+
+    case .basicCancel(let m):
+      try encoder.writeShortString(m.consumerTag)
+      encoder.writeBits([m.noWait])
+
+    case .basicCancelOk(let m):
+      try encoder.writeShortString(m.consumerTag)
+
+    case .basicPublish(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.exchange)
+      try encoder.writeShortString(m.routingKey)
+      encoder.writeBits([m.mandatory, m.immediate])
+
+    case .basicReturn(let m):
+      encoder.writeUInt16(m.replyCode)
+      try encoder.writeShortString(m.replyText)
+      try encoder.writeShortString(m.exchange)
+      try encoder.writeShortString(m.routingKey)
+
+    case .basicDeliver(let m):
+      try encoder.writeShortString(m.consumerTag)
+      encoder.writeUInt64(m.deliveryTag)
+      encoder.writeBits([m.redelivered])
+      try encoder.writeShortString(m.exchange)
+      try encoder.writeShortString(m.routingKey)
+
+    case .basicGet(let m):
+      encoder.writeUInt16(m.reserved1)
+      try encoder.writeShortString(m.queue)
+      encoder.writeBits([m.noAck])
+
+    case .basicGetOk(let m):
+      encoder.writeUInt64(m.deliveryTag)
+      encoder.writeBits([m.redelivered])
+      try encoder.writeShortString(m.exchange)
+      try encoder.writeShortString(m.routingKey)
+      encoder.writeUInt32(m.messageCount)
+
+    case .basicGetEmpty(let m):
+      try encoder.writeShortString(m.reserved1)
+
+    case .basicAck(let m):
+      encoder.writeUInt64(m.deliveryTag)
+      encoder.writeBits([m.multiple])
+
+    case .basicReject(let m):
+      encoder.writeUInt64(m.deliveryTag)
+      encoder.writeBits([m.requeue])
+
+    case .basicRecoverAsync(let m):
+      encoder.writeBits([m.requeue])
+
+    case .basicRecover(let m):
+      encoder.writeBits([m.requeue])
+
+    case .basicRecoverOk:
+      break
+
+    case .basicNack(let m):
+      encoder.writeUInt64(m.deliveryTag)
+      encoder.writeBits([m.multiple, m.requeue])
+
+    // Tx class
+    case .txSelect, .txSelectOk, .txCommit, .txCommitOk, .txRollback, .txRollbackOk:
+      break  // no payload
+
+    // Confirm class
+    case .confirmSelect(let m):
+      encoder.writeBits([m.noWait])
+
+    case .confirmSelectOk:
+      break
     }
-
-    private func decodeMethodPayload(_ data: Data) throws -> Method {
-        var decoder = data.wireDecoder()
-        let classID = try decoder.readUInt16()
-        let methodID = try decoder.readUInt16()
-
-        switch (classID, methodID) {
-        // Connection class (10)
-        case (10, 10):  // Start
-            let versionMajor = try decoder.readUInt8()
-            let versionMinor = try decoder.readUInt8()
-            let serverProperties = try decodeTable(from: &decoder)
-            let mechanisms = try decoder.readLongString()
-            let locales = try decoder.readLongString()
-            return .connectionStart(ConnectionStart(
-                versionMajor: versionMajor,
-                versionMinor: versionMinor,
-                serverProperties: serverProperties,
-                mechanisms: mechanisms,
-                locales: locales
-            ))
-
-        case (10, 11):  // StartOk
-            let clientProperties = try decodeTable(from: &decoder)
-            let mechanism = try decoder.readShortString()
-            let response = try decoder.readLongString()
-            let locale = try decoder.readShortString()
-            return .connectionStartOk(ConnectionStartOk(
-                clientProperties: clientProperties,
-                mechanism: mechanism,
-                response: response,
-                locale: locale
-            ))
-
-        case (10, 20):  // Secure
-            let challenge = try decoder.readLongString()
-            return .connectionSecure(ConnectionSecure(challenge: challenge))
-
-        case (10, 21):  // SecureOk
-            let response = try decoder.readLongString()
-            return .connectionSecureOk(ConnectionSecureOk(response: response))
-
-        case (10, 30):  // Tune
-            let channelMax = try decoder.readUInt16()
-            let frameMax = try decoder.readUInt32()
-            let heartbeat = try decoder.readUInt16()
-            return .connectionTune(ConnectionTune(channelMax: channelMax, frameMax: frameMax, heartbeat: heartbeat))
-
-        case (10, 31):  // TuneOk
-            let channelMax = try decoder.readUInt16()
-            let frameMax = try decoder.readUInt32()
-            let heartbeat = try decoder.readUInt16()
-            return .connectionTuneOk(ConnectionTuneOk(channelMax: channelMax, frameMax: frameMax, heartbeat: heartbeat))
-
-        case (10, 40):  // Open
-            let virtualHost = try decoder.readShortString()
-            let reserved1 = try decoder.readShortString()
-            let bits = try decoder.readBits(1)
-            return .connectionOpen(ConnectionOpen(virtualHost: virtualHost, reserved1: reserved1, reserved2: bits[0]))
-
-        case (10, 41):  // OpenOk
-            let reserved1 = try decoder.readShortString()
-            return .connectionOpenOk(ConnectionOpenOk(reserved1: reserved1))
-
-        case (10, 50):  // Close
-            let replyCode = try decoder.readUInt16()
-            let replyText = try decoder.readShortString()
-            let classId = try decoder.readUInt16()
-            let methodId = try decoder.readUInt16()
-            return .connectionClose(ConnectionClose(replyCode: replyCode, replyText: replyText, classId: classId, methodId: methodId))
-
-        case (10, 51):  // CloseOk
-            return .connectionCloseOk
-
-        case (10, 60):  // Blocked
-            let reason = try decoder.readShortString()
-            return .connectionBlocked(ConnectionBlocked(reason: reason))
-
-        case (10, 61):  // Unblocked
-            return .connectionUnblocked
-
-        // Channel class (20)
-        case (20, 10):  // Open
-            let reserved1 = try decoder.readShortString()
-            return .channelOpen(ChannelOpen(reserved1: reserved1))
-
-        case (20, 11):  // OpenOk
-            let reserved1 = try decoder.readLongString()
-            return .channelOpenOk(ChannelOpenOk(reserved1: reserved1))
-
-        case (20, 20):  // Flow
-            let bits = try decoder.readBits(1)
-            return .channelFlow(ChannelFlow(active: bits[0]))
-
-        case (20, 21):  // FlowOk
-            let bits = try decoder.readBits(1)
-            return .channelFlowOk(ChannelFlowOk(active: bits[0]))
-
-        case (20, 40):  // Close
-            let replyCode = try decoder.readUInt16()
-            let replyText = try decoder.readShortString()
-            let classId = try decoder.readUInt16()
-            let methodId = try decoder.readUInt16()
-            return .channelClose(ChannelClose(replyCode: replyCode, replyText: replyText, classId: classId, methodId: methodId))
-
-        case (20, 41):  // CloseOk
-            return .channelCloseOk
-
-        // Exchange class (40)
-        case (40, 10):  // Declare
-            let reserved1 = try decoder.readUInt16()
-            let exchange = try decoder.readShortString()
-            let type = try decoder.readShortString()
-            let bits = try decoder.readBits(5)
-            let arguments = try decodeTable(from: &decoder)
-            return .exchangeDeclare(ExchangeDeclare(
-                reserved1: reserved1, exchange: exchange, type: type,
-                passive: bits[0], durable: bits[1], autoDelete: bits[2],
-                internal: bits[3], noWait: bits[4], arguments: arguments
-            ))
-
-        case (40, 11):  // DeclareOk
-            return .exchangeDeclareOk
-
-        case (40, 20):  // Delete
-            let reserved1 = try decoder.readUInt16()
-            let exchange = try decoder.readShortString()
-            let bits = try decoder.readBits(2)
-            return .exchangeDelete(ExchangeDelete(reserved1: reserved1, exchange: exchange, ifUnused: bits[0], noWait: bits[1]))
-
-        case (40, 21):  // DeleteOk
-            return .exchangeDeleteOk
-
-        case (40, 30):  // Bind
-            let reserved1 = try decoder.readUInt16()
-            let destination = try decoder.readShortString()
-            let source = try decoder.readShortString()
-            let routingKey = try decoder.readShortString()
-            let bits = try decoder.readBits(1)
-            let arguments = try decodeTable(from: &decoder)
-            return .exchangeBind(ExchangeBind(
-                reserved1: reserved1, destination: destination, source: source,
-                routingKey: routingKey, noWait: bits[0], arguments: arguments
-            ))
-
-        case (40, 31):  // BindOk
-            return .exchangeBindOk
-
-        case (40, 40):  // Unbind
-            let reserved1 = try decoder.readUInt16()
-            let destination = try decoder.readShortString()
-            let source = try decoder.readShortString()
-            let routingKey = try decoder.readShortString()
-            let bits = try decoder.readBits(1)
-            let arguments = try decodeTable(from: &decoder)
-            return .exchangeUnbind(ExchangeUnbind(
-                reserved1: reserved1, destination: destination, source: source,
-                routingKey: routingKey, noWait: bits[0], arguments: arguments
-            ))
-
-        case (40, 51):  // UnbindOk
-            return .exchangeUnbindOk
-
-        // Queue class (50)
-        case (50, 10):  // Declare
-            let reserved1 = try decoder.readUInt16()
-            let queue = try decoder.readShortString()
-            let bits = try decoder.readBits(5)
-            let arguments = try decodeTable(from: &decoder)
-            return .queueDeclare(QueueDeclare(
-                reserved1: reserved1, queue: queue,
-                passive: bits[0], durable: bits[1], exclusive: bits[2],
-                autoDelete: bits[3], noWait: bits[4], arguments: arguments
-            ))
-
-        case (50, 11):  // DeclareOk
-            let queue = try decoder.readShortString()
-            let messageCount = try decoder.readUInt32()
-            let consumerCount = try decoder.readUInt32()
-            return .queueDeclareOk(QueueDeclareOk(queue: queue, messageCount: messageCount, consumerCount: consumerCount))
-
-        case (50, 20):  // Bind
-            let reserved1 = try decoder.readUInt16()
-            let queue = try decoder.readShortString()
-            let exchange = try decoder.readShortString()
-            let routingKey = try decoder.readShortString()
-            let bits = try decoder.readBits(1)
-            let arguments = try decodeTable(from: &decoder)
-            return .queueBind(QueueBind(
-                reserved1: reserved1, queue: queue, exchange: exchange,
-                routingKey: routingKey, noWait: bits[0], arguments: arguments
-            ))
-
-        case (50, 21):  // BindOk
-            return .queueBindOk
-
-        case (50, 30):  // Purge
-            let reserved1 = try decoder.readUInt16()
-            let queue = try decoder.readShortString()
-            let bits = try decoder.readBits(1)
-            return .queuePurge(QueuePurge(reserved1: reserved1, queue: queue, noWait: bits[0]))
-
-        case (50, 31):  // PurgeOk
-            let messageCount = try decoder.readUInt32()
-            return .queuePurgeOk(QueuePurgeOk(messageCount: messageCount))
-
-        case (50, 40):  // Delete
-            let reserved1 = try decoder.readUInt16()
-            let queue = try decoder.readShortString()
-            let bits = try decoder.readBits(3)
-            return .queueDelete(QueueDelete(
-                reserved1: reserved1, queue: queue,
-                ifUnused: bits[0], ifEmpty: bits[1], noWait: bits[2]
-            ))
-
-        case (50, 41):  // DeleteOk
-            let messageCount = try decoder.readUInt32()
-            return .queueDeleteOk(QueueDeleteOk(messageCount: messageCount))
-
-        case (50, 50):  // Unbind
-            let reserved1 = try decoder.readUInt16()
-            let queue = try decoder.readShortString()
-            let exchange = try decoder.readShortString()
-            let routingKey = try decoder.readShortString()
-            let arguments = try decodeTable(from: &decoder)
-            return .queueUnbind(QueueUnbind(
-                reserved1: reserved1, queue: queue, exchange: exchange,
-                routingKey: routingKey, arguments: arguments
-            ))
-
-        case (50, 51):  // UnbindOk
-            return .queueUnbindOk
-
-        // Basic class (60)
-        case (60, 10):  // Qos
-            let prefetchSize = try decoder.readUInt32()
-            let prefetchCount = try decoder.readUInt16()
-            let bits = try decoder.readBits(1)
-            return .basicQos(BasicQos(prefetchSize: prefetchSize, prefetchCount: prefetchCount, global: bits[0]))
-
-        case (60, 11):  // QosOk
-            return .basicQosOk
-
-        case (60, 20):  // Consume
-            let reserved1 = try decoder.readUInt16()
-            let queue = try decoder.readShortString()
-            let consumerTag = try decoder.readShortString()
-            let bits = try decoder.readBits(4)
-            let arguments = try decodeTable(from: &decoder)
-            return .basicConsume(BasicConsume(
-                reserved1: reserved1, queue: queue, consumerTag: consumerTag,
-                noLocal: bits[0], noAck: bits[1], exclusive: bits[2],
-                noWait: bits[3], arguments: arguments
-            ))
-
-        case (60, 21):  // ConsumeOk
-            let consumerTag = try decoder.readShortString()
-            return .basicConsumeOk(BasicConsumeOk(consumerTag: consumerTag))
-
-        case (60, 30):  // Cancel
-            let consumerTag = try decoder.readShortString()
-            let bits = try decoder.readBits(1)
-            return .basicCancel(BasicCancel(consumerTag: consumerTag, noWait: bits[0]))
-
-        case (60, 31):  // CancelOk
-            let consumerTag = try decoder.readShortString()
-            return .basicCancelOk(BasicCancelOk(consumerTag: consumerTag))
-
-        case (60, 40):  // Publish
-            let reserved1 = try decoder.readUInt16()
-            let exchange = try decoder.readShortString()
-            let routingKey = try decoder.readShortString()
-            let bits = try decoder.readBits(2)
-            return .basicPublish(BasicPublish(
-                reserved1: reserved1, exchange: exchange, routingKey: routingKey,
-                mandatory: bits[0], immediate: bits[1]
-            ))
-
-        case (60, 50):  // Return
-            let replyCode = try decoder.readUInt16()
-            let replyText = try decoder.readShortString()
-            let exchange = try decoder.readShortString()
-            let routingKey = try decoder.readShortString()
-            return .basicReturn(BasicReturn(replyCode: replyCode, replyText: replyText, exchange: exchange, routingKey: routingKey))
-
-        case (60, 60):  // Deliver
-            let consumerTag = try decoder.readShortString()
-            let deliveryTag = try decoder.readUInt64()
-            let bits = try decoder.readBits(1)
-            let exchange = try decoder.readShortString()
-            let routingKey = try decoder.readShortString()
-            return .basicDeliver(BasicDeliver(
-                consumerTag: consumerTag, deliveryTag: deliveryTag,
-                redelivered: bits[0], exchange: exchange, routingKey: routingKey
-            ))
-
-        case (60, 70):  // Get
-            let reserved1 = try decoder.readUInt16()
-            let queue = try decoder.readShortString()
-            let bits = try decoder.readBits(1)
-            return .basicGet(BasicGet(reserved1: reserved1, queue: queue, noAck: bits[0]))
-
-        case (60, 71):  // GetOk
-            let deliveryTag = try decoder.readUInt64()
-            let bits = try decoder.readBits(1)
-            let exchange = try decoder.readShortString()
-            let routingKey = try decoder.readShortString()
-            let messageCount = try decoder.readUInt32()
-            return .basicGetOk(BasicGetOk(
-                deliveryTag: deliveryTag, redelivered: bits[0],
-                exchange: exchange, routingKey: routingKey, messageCount: messageCount
-            ))
-
-        case (60, 72):  // GetEmpty
-            let reserved1 = try decoder.readShortString()
-            return .basicGetEmpty(BasicGetEmpty(reserved1: reserved1))
-
-        case (60, 80):  // Ack
-            let deliveryTag = try decoder.readUInt64()
-            let bits = try decoder.readBits(1)
-            return .basicAck(BasicAck(deliveryTag: deliveryTag, multiple: bits[0]))
-
-        case (60, 90):  // Reject
-            let deliveryTag = try decoder.readUInt64()
-            let bits = try decoder.readBits(1)
-            return .basicReject(BasicReject(deliveryTag: deliveryTag, requeue: bits[0]))
-
-        case (60, 100):  // RecoverAsync
-            let bits = try decoder.readBits(1)
-            return .basicRecoverAsync(BasicRecoverAsync(requeue: bits[0]))
-
-        case (60, 110):  // Recover
-            let bits = try decoder.readBits(1)
-            return .basicRecover(BasicRecover(requeue: bits[0]))
-
-        case (60, 111):  // RecoverOk
-            return .basicRecoverOk
-
-        case (60, 120):  // Nack
-            let deliveryTag = try decoder.readUInt64()
-            let bits = try decoder.readBits(2)
-            return .basicNack(BasicNack(deliveryTag: deliveryTag, multiple: bits[0], requeue: bits[1]))
-
-        // Tx class (90)
-        case (90, 10):  // Select
-            return .txSelect
-
-        case (90, 11):  // SelectOk
-            return .txSelectOk
-
-        case (90, 20):  // Commit
-            return .txCommit
-
-        case (90, 21):  // CommitOk
-            return .txCommitOk
-
-        case (90, 30):  // Rollback
-            return .txRollback
-
-        case (90, 31):  // RollbackOk
-            return .txRollbackOk
-
-        // Confirm class (85)
-        case (85, 10):  // Select
-            let bits = try decoder.readBits(1)
-            return .confirmSelect(ConfirmSelect(noWait: bits[0]))
-
-        case (85, 11):  // SelectOk
-            return .confirmSelectOk
-
-        default:
-            throw AMQPProtocolError.unknownMethod(classID: classID, methodID: methodID)
-        }
+  }
+
+  // MARK: - Method Payload Decoding
+
+  public func decodeMethod(from data: Data) throws -> Method {
+    try decodeMethodPayload(data)
+  }
+
+  private func decodeMethodPayload(_ data: Data) throws -> Method {
+    var decoder = data.wireDecoder()
+    let classID = try decoder.readUInt16()
+    let methodID = try decoder.readUInt16()
+
+    switch (classID, methodID) {
+    // Connection class (10)
+    case (10, 10):  // Start
+      let versionMajor = try decoder.readUInt8()
+      let versionMinor = try decoder.readUInt8()
+      let serverProperties = try decodeTable(from: &decoder)
+      let mechanisms = try decoder.readLongString()
+      let locales = try decoder.readLongString()
+      return .connectionStart(
+        ConnectionStart(
+          versionMajor: versionMajor,
+          versionMinor: versionMinor,
+          serverProperties: serverProperties,
+          mechanisms: mechanisms,
+          locales: locales
+        ))
+
+    case (10, 11):  // StartOk
+      let clientProperties = try decodeTable(from: &decoder)
+      let mechanism = try decoder.readShortString()
+      let response = try decoder.readLongString()
+      let locale = try decoder.readShortString()
+      return .connectionStartOk(
+        ConnectionStartOk(
+          clientProperties: clientProperties,
+          mechanism: mechanism,
+          response: response,
+          locale: locale
+        ))
+
+    case (10, 20):  // Secure
+      let challenge = try decoder.readLongString()
+      return .connectionSecure(ConnectionSecure(challenge: challenge))
+
+    case (10, 21):  // SecureOk
+      let response = try decoder.readLongString()
+      return .connectionSecureOk(ConnectionSecureOk(response: response))
+
+    case (10, 30):  // Tune
+      let channelMax = try decoder.readUInt16()
+      let frameMax = try decoder.readUInt32()
+      let heartbeat = try decoder.readUInt16()
+      return .connectionTune(
+        ConnectionTune(channelMax: channelMax, frameMax: frameMax, heartbeat: heartbeat))
+
+    case (10, 31):  // TuneOk
+      let channelMax = try decoder.readUInt16()
+      let frameMax = try decoder.readUInt32()
+      let heartbeat = try decoder.readUInt16()
+      return .connectionTuneOk(
+        ConnectionTuneOk(channelMax: channelMax, frameMax: frameMax, heartbeat: heartbeat))
+
+    case (10, 40):  // Open
+      let virtualHost = try decoder.readShortString()
+      let reserved1 = try decoder.readShortString()
+      let bits = try decoder.readBits(1)
+      return .connectionOpen(
+        ConnectionOpen(virtualHost: virtualHost, reserved1: reserved1, reserved2: bits[0]))
+
+    case (10, 41):  // OpenOk
+      let reserved1 = try decoder.readShortString()
+      return .connectionOpenOk(ConnectionOpenOk(reserved1: reserved1))
+
+    case (10, 50):  // Close
+      let replyCode = try decoder.readUInt16()
+      let replyText = try decoder.readShortString()
+      let classId = try decoder.readUInt16()
+      let methodId = try decoder.readUInt16()
+      return .connectionClose(
+        ConnectionClose(
+          replyCode: replyCode, replyText: replyText, classId: classId, methodId: methodId))
+
+    case (10, 51):  // CloseOk
+      return .connectionCloseOk
+
+    case (10, 60):  // Blocked
+      let reason = try decoder.readShortString()
+      return .connectionBlocked(ConnectionBlocked(reason: reason))
+
+    case (10, 61):  // Unblocked
+      return .connectionUnblocked
+
+    // Channel class (20)
+    case (20, 10):  // Open
+      let reserved1 = try decoder.readShortString()
+      return .channelOpen(ChannelOpen(reserved1: reserved1))
+
+    case (20, 11):  // OpenOk
+      let reserved1 = try decoder.readLongString()
+      return .channelOpenOk(ChannelOpenOk(reserved1: reserved1))
+
+    case (20, 20):  // Flow
+      let bits = try decoder.readBits(1)
+      return .channelFlow(ChannelFlow(active: bits[0]))
+
+    case (20, 21):  // FlowOk
+      let bits = try decoder.readBits(1)
+      return .channelFlowOk(ChannelFlowOk(active: bits[0]))
+
+    case (20, 40):  // Close
+      let replyCode = try decoder.readUInt16()
+      let replyText = try decoder.readShortString()
+      let classId = try decoder.readUInt16()
+      let methodId = try decoder.readUInt16()
+      return .channelClose(
+        ChannelClose(
+          replyCode: replyCode, replyText: replyText, classId: classId, methodId: methodId))
+
+    case (20, 41):  // CloseOk
+      return .channelCloseOk
+
+    // Exchange class (40)
+    case (40, 10):  // Declare
+      let reserved1 = try decoder.readUInt16()
+      let exchange = try decoder.readShortString()
+      let type = try decoder.readShortString()
+      let bits = try decoder.readBits(5)
+      let arguments = try decodeTable(from: &decoder)
+      return .exchangeDeclare(
+        ExchangeDeclare(
+          reserved1: reserved1, exchange: exchange, type: type,
+          passive: bits[0], durable: bits[1], autoDelete: bits[2],
+          internal: bits[3], noWait: bits[4], arguments: arguments
+        ))
+
+    case (40, 11):  // DeclareOk
+      return .exchangeDeclareOk
+
+    case (40, 20):  // Delete
+      let reserved1 = try decoder.readUInt16()
+      let exchange = try decoder.readShortString()
+      let bits = try decoder.readBits(2)
+      return .exchangeDelete(
+        ExchangeDelete(reserved1: reserved1, exchange: exchange, ifUnused: bits[0], noWait: bits[1])
+      )
+
+    case (40, 21):  // DeleteOk
+      return .exchangeDeleteOk
+
+    case (40, 30):  // Bind
+      let reserved1 = try decoder.readUInt16()
+      let destination = try decoder.readShortString()
+      let source = try decoder.readShortString()
+      let routingKey = try decoder.readShortString()
+      let bits = try decoder.readBits(1)
+      let arguments = try decodeTable(from: &decoder)
+      return .exchangeBind(
+        ExchangeBind(
+          reserved1: reserved1, destination: destination, source: source,
+          routingKey: routingKey, noWait: bits[0], arguments: arguments
+        ))
+
+    case (40, 31):  // BindOk
+      return .exchangeBindOk
+
+    case (40, 40):  // Unbind
+      let reserved1 = try decoder.readUInt16()
+      let destination = try decoder.readShortString()
+      let source = try decoder.readShortString()
+      let routingKey = try decoder.readShortString()
+      let bits = try decoder.readBits(1)
+      let arguments = try decodeTable(from: &decoder)
+      return .exchangeUnbind(
+        ExchangeUnbind(
+          reserved1: reserved1, destination: destination, source: source,
+          routingKey: routingKey, noWait: bits[0], arguments: arguments
+        ))
+
+    case (40, 51):  // UnbindOk
+      return .exchangeUnbindOk
+
+    // Queue class (50)
+    case (50, 10):  // Declare
+      let reserved1 = try decoder.readUInt16()
+      let queue = try decoder.readShortString()
+      let bits = try decoder.readBits(5)
+      let arguments = try decodeTable(from: &decoder)
+      return .queueDeclare(
+        QueueDeclare(
+          reserved1: reserved1, queue: queue,
+          passive: bits[0], durable: bits[1], exclusive: bits[2],
+          autoDelete: bits[3], noWait: bits[4], arguments: arguments
+        ))
+
+    case (50, 11):  // DeclareOk
+      let queue = try decoder.readShortString()
+      let messageCount = try decoder.readUInt32()
+      let consumerCount = try decoder.readUInt32()
+      return .queueDeclareOk(
+        QueueDeclareOk(queue: queue, messageCount: messageCount, consumerCount: consumerCount))
+
+    case (50, 20):  // Bind
+      let reserved1 = try decoder.readUInt16()
+      let queue = try decoder.readShortString()
+      let exchange = try decoder.readShortString()
+      let routingKey = try decoder.readShortString()
+      let bits = try decoder.readBits(1)
+      let arguments = try decodeTable(from: &decoder)
+      return .queueBind(
+        QueueBind(
+          reserved1: reserved1, queue: queue, exchange: exchange,
+          routingKey: routingKey, noWait: bits[0], arguments: arguments
+        ))
+
+    case (50, 21):  // BindOk
+      return .queueBindOk
+
+    case (50, 30):  // Purge
+      let reserved1 = try decoder.readUInt16()
+      let queue = try decoder.readShortString()
+      let bits = try decoder.readBits(1)
+      return .queuePurge(QueuePurge(reserved1: reserved1, queue: queue, noWait: bits[0]))
+
+    case (50, 31):  // PurgeOk
+      let messageCount = try decoder.readUInt32()
+      return .queuePurgeOk(QueuePurgeOk(messageCount: messageCount))
+
+    case (50, 40):  // Delete
+      let reserved1 = try decoder.readUInt16()
+      let queue = try decoder.readShortString()
+      let bits = try decoder.readBits(3)
+      return .queueDelete(
+        QueueDelete(
+          reserved1: reserved1, queue: queue,
+          ifUnused: bits[0], ifEmpty: bits[1], noWait: bits[2]
+        ))
+
+    case (50, 41):  // DeleteOk
+      let messageCount = try decoder.readUInt32()
+      return .queueDeleteOk(QueueDeleteOk(messageCount: messageCount))
+
+    case (50, 50):  // Unbind
+      let reserved1 = try decoder.readUInt16()
+      let queue = try decoder.readShortString()
+      let exchange = try decoder.readShortString()
+      let routingKey = try decoder.readShortString()
+      let arguments = try decodeTable(from: &decoder)
+      return .queueUnbind(
+        QueueUnbind(
+          reserved1: reserved1, queue: queue, exchange: exchange,
+          routingKey: routingKey, arguments: arguments
+        ))
+
+    case (50, 51):  // UnbindOk
+      return .queueUnbindOk
+
+    // Basic class (60)
+    case (60, 10):  // Qos
+      let prefetchSize = try decoder.readUInt32()
+      let prefetchCount = try decoder.readUInt16()
+      let bits = try decoder.readBits(1)
+      return .basicQos(
+        BasicQos(prefetchSize: prefetchSize, prefetchCount: prefetchCount, global: bits[0]))
+
+    case (60, 11):  // QosOk
+      return .basicQosOk
+
+    case (60, 20):  // Consume
+      let reserved1 = try decoder.readUInt16()
+      let queue = try decoder.readShortString()
+      let consumerTag = try decoder.readShortString()
+      let bits = try decoder.readBits(4)
+      let arguments = try decodeTable(from: &decoder)
+      return .basicConsume(
+        BasicConsume(
+          reserved1: reserved1, queue: queue, consumerTag: consumerTag,
+          noLocal: bits[0], noAck: bits[1], exclusive: bits[2],
+          noWait: bits[3], arguments: arguments
+        ))
+
+    case (60, 21):  // ConsumeOk
+      let consumerTag = try decoder.readShortString()
+      return .basicConsumeOk(BasicConsumeOk(consumerTag: consumerTag))
+
+    case (60, 30):  // Cancel
+      let consumerTag = try decoder.readShortString()
+      let bits = try decoder.readBits(1)
+      return .basicCancel(BasicCancel(consumerTag: consumerTag, noWait: bits[0]))
+
+    case (60, 31):  // CancelOk
+      let consumerTag = try decoder.readShortString()
+      return .basicCancelOk(BasicCancelOk(consumerTag: consumerTag))
+
+    case (60, 40):  // Publish
+      let reserved1 = try decoder.readUInt16()
+      let exchange = try decoder.readShortString()
+      let routingKey = try decoder.readShortString()
+      let bits = try decoder.readBits(2)
+      return .basicPublish(
+        BasicPublish(
+          reserved1: reserved1, exchange: exchange, routingKey: routingKey,
+          mandatory: bits[0], immediate: bits[1]
+        ))
+
+    case (60, 50):  // Return
+      let replyCode = try decoder.readUInt16()
+      let replyText = try decoder.readShortString()
+      let exchange = try decoder.readShortString()
+      let routingKey = try decoder.readShortString()
+      return .basicReturn(
+        BasicReturn(
+          replyCode: replyCode, replyText: replyText, exchange: exchange, routingKey: routingKey))
+
+    case (60, 60):  // Deliver
+      let consumerTag = try decoder.readShortString()
+      let deliveryTag = try decoder.readUInt64()
+      let bits = try decoder.readBits(1)
+      let exchange = try decoder.readShortString()
+      let routingKey = try decoder.readShortString()
+      return .basicDeliver(
+        BasicDeliver(
+          consumerTag: consumerTag, deliveryTag: deliveryTag,
+          redelivered: bits[0], exchange: exchange, routingKey: routingKey
+        ))
+
+    case (60, 70):  // Get
+      let reserved1 = try decoder.readUInt16()
+      let queue = try decoder.readShortString()
+      let bits = try decoder.readBits(1)
+      return .basicGet(BasicGet(reserved1: reserved1, queue: queue, noAck: bits[0]))
+
+    case (60, 71):  // GetOk
+      let deliveryTag = try decoder.readUInt64()
+      let bits = try decoder.readBits(1)
+      let exchange = try decoder.readShortString()
+      let routingKey = try decoder.readShortString()
+      let messageCount = try decoder.readUInt32()
+      return .basicGetOk(
+        BasicGetOk(
+          deliveryTag: deliveryTag, redelivered: bits[0],
+          exchange: exchange, routingKey: routingKey, messageCount: messageCount
+        ))
+
+    case (60, 72):  // GetEmpty
+      let reserved1 = try decoder.readShortString()
+      return .basicGetEmpty(BasicGetEmpty(reserved1: reserved1))
+
+    case (60, 80):  // Ack
+      let deliveryTag = try decoder.readUInt64()
+      let bits = try decoder.readBits(1)
+      return .basicAck(BasicAck(deliveryTag: deliveryTag, multiple: bits[0]))
+
+    case (60, 90):  // Reject
+      let deliveryTag = try decoder.readUInt64()
+      let bits = try decoder.readBits(1)
+      return .basicReject(BasicReject(deliveryTag: deliveryTag, requeue: bits[0]))
+
+    case (60, 100):  // RecoverAsync
+      let bits = try decoder.readBits(1)
+      return .basicRecoverAsync(BasicRecoverAsync(requeue: bits[0]))
+
+    case (60, 110):  // Recover
+      let bits = try decoder.readBits(1)
+      return .basicRecover(BasicRecover(requeue: bits[0]))
+
+    case (60, 111):  // RecoverOk
+      return .basicRecoverOk
+
+    case (60, 120):  // Nack
+      let deliveryTag = try decoder.readUInt64()
+      let bits = try decoder.readBits(2)
+      return .basicNack(BasicNack(deliveryTag: deliveryTag, multiple: bits[0], requeue: bits[1]))
+
+    // Tx class (90)
+    case (90, 10):  // Select
+      return .txSelect
+
+    case (90, 11):  // SelectOk
+      return .txSelectOk
+
+    case (90, 20):  // Commit
+      return .txCommit
+
+    case (90, 21):  // CommitOk
+      return .txCommitOk
+
+    case (90, 30):  // Rollback
+      return .txRollback
+
+    case (90, 31):  // RollbackOk
+      return .txRollbackOk
+
+    // Confirm class (85)
+    case (85, 10):  // Select
+      let bits = try decoder.readBits(1)
+      return .confirmSelect(ConfirmSelect(noWait: bits[0]))
+
+    case (85, 11):  // SelectOk
+      return .confirmSelectOk
+
+    default:
+      throw AMQPProtocolError.unknownMethod(classID: classID, methodID: methodID)
     }
+  }
 }
 
 // MARK: - Protocol Errors
 
 public enum AMQPProtocolError: Error, Sendable {
-    case unknownMethod(classID: UInt16, methodID: UInt16)
+  case unknownMethod(classID: UInt16, methodID: UInt16)
 }

--- a/Sources/AMQPProtocol/Types.swift
+++ b/Sources/AMQPProtocol/Types.swift
@@ -14,566 +14,567 @@ public typealias Table = [String: FieldValue]
 // MARK: - Field Value
 
 public enum FieldValue: Sendable, Equatable, Hashable {
-    case boolean(Bool)
-    case int8(Int8)
-    case uint8(UInt8)
-    case int16(Int16)
-    case uint16(UInt16)
-    case int32(Int32)
-    case uint32(UInt32)
-    case int64(Int64)
-    case float(Float)
-    case double(Double)
-    case decimal(scale: UInt8, value: UInt32)
-    case string(String)
-    case bytes(Data)
-    case array([FieldValue])
-    case timestamp(Date)
-    case table(Table)
-    case void
+  case boolean(Bool)
+  case int8(Int8)
+  case uint8(UInt8)
+  case int16(Int16)
+  case uint16(UInt16)
+  case int32(Int32)
+  case uint32(UInt32)
+  case int64(Int64)
+  case float(Float)
+  case double(Double)
+  case decimal(scale: UInt8, value: UInt32)
+  case string(String)
+  case bytes(Data)
+  case array([FieldValue])
+  case timestamp(Date)
+  case table(Table)
+  case void
 }
 
 // MARK: - ExpressibleByLiteral Conformances
 
 extension FieldValue: ExpressibleByBooleanLiteral {
-    public init(booleanLiteral value: Bool) {
-        self = .boolean(value)
-    }
+  public init(booleanLiteral value: Bool) {
+    self = .boolean(value)
+  }
 }
 
 extension FieldValue: ExpressibleByIntegerLiteral {
-    public init(integerLiteral value: Int64) {
-        self = .int64(value)
-    }
+  public init(integerLiteral value: Int64) {
+    self = .int64(value)
+  }
 }
 
 extension FieldValue: ExpressibleByFloatLiteral {
-    public init(floatLiteral value: Double) {
-        self = .double(value)
-    }
+  public init(floatLiteral value: Double) {
+    self = .double(value)
+  }
 }
 
 extension FieldValue: ExpressibleByStringLiteral {
-    public init(stringLiteral value: String) {
-        self = .string(value)
-    }
+  public init(stringLiteral value: String) {
+    self = .string(value)
+  }
 }
 
 extension FieldValue: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: FieldValue...) {
-        self = .array(elements)
-    }
+  public init(arrayLiteral elements: FieldValue...) {
+    self = .array(elements)
+  }
 }
 
 extension FieldValue: ExpressibleByDictionaryLiteral {
-    public init(dictionaryLiteral elements: (String, FieldValue)...) {
-        self = .table(Dictionary(uniqueKeysWithValues: elements))
-    }
+  public init(dictionaryLiteral elements: (String, FieldValue)...) {
+    self = .table(Dictionary(uniqueKeysWithValues: elements))
+  }
 }
 
 extension FieldValue: ExpressibleByNilLiteral {
-    public init(nilLiteral: ()) {
-        self = .void
-    }
+  public init(nilLiteral: ()) {
+    self = .void
+  }
 }
 
 // MARK: - Convenience Accessors
 
 extension FieldValue {
-    public var boolValue: Bool? {
-        if case .boolean(let v) = self { return v }
-        return nil
-    }
+  public var boolValue: Bool? {
+    if case .boolean(let v) = self { return v }
+    return nil
+  }
 
-    /// Coerces from smaller integer types
-    public var intValue: Int64? {
-        switch self {
-        case .int8(let v): return Int64(v)
-        case .uint8(let v): return Int64(v)
-        case .int16(let v): return Int64(v)
-        case .uint16(let v): return Int64(v)
-        case .int32(let v): return Int64(v)
-        case .uint32(let v): return Int64(v)
-        case .int64(let v): return v
-        default: return nil
-        }
+  /// Coerces from smaller integer types
+  public var intValue: Int64? {
+    switch self {
+    case .int8(let v): return Int64(v)
+    case .uint8(let v): return Int64(v)
+    case .int16(let v): return Int64(v)
+    case .uint16(let v): return Int64(v)
+    case .int32(let v): return Int64(v)
+    case .uint32(let v): return Int64(v)
+    case .int64(let v): return v
+    default: return nil
     }
+  }
 
-    public var doubleValue: Double? {
-        switch self {
-        case .float(let v): return Double(v)
-        case .double(let v): return v
-        default: return nil
-        }
+  public var doubleValue: Double? {
+    switch self {
+    case .float(let v): return Double(v)
+    case .double(let v): return v
+    default: return nil
     }
+  }
 
-    public var stringValue: String? {
-        if case .string(let v) = self { return v }
-        return nil
-    }
+  public var stringValue: String? {
+    if case .string(let v) = self { return v }
+    return nil
+  }
 
-    public var dataValue: Data? {
-        if case .bytes(let v) = self { return v }
-        return nil
-    }
+  public var dataValue: Data? {
+    if case .bytes(let v) = self { return v }
+    return nil
+  }
 
-    public var dateValue: Date? {
-        if case .timestamp(let v) = self { return v }
-        return nil
-    }
+  public var dateValue: Date? {
+    if case .timestamp(let v) = self { return v }
+    return nil
+  }
 
-    public var arrayValue: [FieldValue]? {
-        if case .array(let v) = self { return v }
-        return nil
-    }
+  public var arrayValue: [FieldValue]? {
+    if case .array(let v) = self { return v }
+    return nil
+  }
 
-    public var tableValue: Table? {
-        if case .table(let v) = self { return v }
-        return nil
-    }
+  public var tableValue: Table? {
+    if case .table(let v) = self { return v }
+    return nil
+  }
 
-    public var isVoid: Bool {
-        if case .void = self { return true }
-        return false
-    }
+  public var isVoid: Bool {
+    if case .void = self { return true }
+    return false
+  }
 }
 
 // MARK: - Table Encoding
 
 extension FieldValue {
-    /// Encode a field value to wire format
-    public func encode(to encoder: inout WireEncoder) throws {
-        switch self {
-        case .boolean(let v):
-            encoder.writeUInt8(0x74)  // 't'
-            encoder.writeBoolean(v)
+  /// Encode a field value to wire format
+  public func encode(to encoder: inout WireEncoder) throws {
+    switch self {
+    case .boolean(let v):
+      encoder.writeUInt8(0x74)  // 't'
+      encoder.writeBoolean(v)
 
-        case .int8(let v):
-            encoder.writeUInt8(0x62)  // 'b'
-            encoder.writeInt8(v)
+    case .int8(let v):
+      encoder.writeUInt8(0x62)  // 'b'
+      encoder.writeInt8(v)
 
-        case .uint8(let v):
-            encoder.writeUInt8(0x42)  // 'B'
-            encoder.writeUInt8(v)
+    case .uint8(let v):
+      encoder.writeUInt8(0x42)  // 'B'
+      encoder.writeUInt8(v)
 
-        case .int16(let v):
-            encoder.writeUInt8(0x73)  // 's'
-            encoder.writeInt16(v)
+    case .int16(let v):
+      encoder.writeUInt8(0x73)  // 's'
+      encoder.writeInt16(v)
 
-        case .uint16(let v):
-            encoder.writeUInt8(0x75)  // 'u'
-            encoder.writeUInt16(v)
+    case .uint16(let v):
+      encoder.writeUInt8(0x75)  // 'u'
+      encoder.writeUInt16(v)
 
-        case .int32(let v):
-            encoder.writeUInt8(0x49)  // 'I'
-            encoder.writeInt32(v)
+    case .int32(let v):
+      encoder.writeUInt8(0x49)  // 'I'
+      encoder.writeInt32(v)
 
-        case .uint32(let v):
-            encoder.writeUInt8(0x69)  // 'i'
-            encoder.writeUInt32(v)
+    case .uint32(let v):
+      encoder.writeUInt8(0x69)  // 'i'
+      encoder.writeUInt32(v)
 
-        case .int64(let v):
-            encoder.writeUInt8(0x6C)  // 'l'
-            encoder.writeInt64(v)
+    case .int64(let v):
+      encoder.writeUInt8(0x6C)  // 'l'
+      encoder.writeInt64(v)
 
-        case .float(let v):
-            encoder.writeUInt8(0x66)  // 'f'
-            encoder.writeFloat(v)
+    case .float(let v):
+      encoder.writeUInt8(0x66)  // 'f'
+      encoder.writeFloat(v)
 
-        case .double(let v):
-            encoder.writeUInt8(0x64)  // 'd'
-            encoder.writeDouble(v)
+    case .double(let v):
+      encoder.writeUInt8(0x64)  // 'd'
+      encoder.writeDouble(v)
 
-        case .decimal(let scale, let value):
-            encoder.writeUInt8(0x44)  // 'D'
-            encoder.writeUInt8(scale)
-            encoder.writeUInt32(value)
+    case .decimal(let scale, let value):
+      encoder.writeUInt8(0x44)  // 'D'
+      encoder.writeUInt8(scale)
+      encoder.writeUInt32(value)
 
-        case .string(let v):
-            encoder.writeUInt8(0x53)  // 'S'
-            encoder.writeLongString(v)
+    case .string(let v):
+      encoder.writeUInt8(0x53)  // 'S'
+      encoder.writeLongString(v)
 
-        case .bytes(let v):
-            encoder.writeUInt8(0x78)  // 'x'
-            encoder.writeLongBytes(v)
+    case .bytes(let v):
+      encoder.writeUInt8(0x78)  // 'x'
+      encoder.writeLongBytes(v)
 
-        case .array(let v):
-            encoder.writeUInt8(0x41)  // 'A'
-            var arrayEncoder = WireEncoder()
-            for element in v {
-                try element.encode(to: &arrayEncoder)
-            }
-            encoder.writeLongBytes(arrayEncoder.encodedData)
+    case .array(let v):
+      encoder.writeUInt8(0x41)  // 'A'
+      var arrayEncoder = WireEncoder()
+      for element in v {
+        try element.encode(to: &arrayEncoder)
+      }
+      encoder.writeLongBytes(arrayEncoder.encodedData)
 
-        case .timestamp(let v):
-            encoder.writeUInt8(0x54)  // 'T'
-            encoder.writeUInt64(UInt64(v.timeIntervalSince1970))
+    case .timestamp(let v):
+      encoder.writeUInt8(0x54)  // 'T'
+      encoder.writeUInt64(UInt64(v.timeIntervalSince1970))
 
-        case .table(let v):
-            encoder.writeUInt8(0x46)  // 'F'
-            try encodeTable(v, to: &encoder)
+    case .table(let v):
+      encoder.writeUInt8(0x46)  // 'F'
+      try encodeTable(v, to: &encoder)
 
-        case .void:
-            encoder.writeUInt8(0x56)  // 'V'
-        }
+    case .void:
+      encoder.writeUInt8(0x56)  // 'V'
     }
+  }
 
-    /// Decode a field value from wire format
-    public static func decode(from decoder: inout WireDecoder) throws -> FieldValue {
-        let typeTag = try decoder.readUInt8()
+  /// Decode a field value from wire format
+  public static func decode(from decoder: inout WireDecoder) throws -> FieldValue {
+    let typeTag = try decoder.readUInt8()
 
-        switch typeTag {
-        case 0x74:  // 't' - boolean
-            return .boolean(try decoder.readBoolean())
+    switch typeTag {
+    case 0x74:  // 't' - boolean
+      return .boolean(try decoder.readBoolean())
 
-        case 0x62:  // 'b' - int8
-            return .int8(try decoder.readInt8())
+    case 0x62:  // 'b' - int8
+      return .int8(try decoder.readInt8())
 
-        case 0x42:  // 'B' - uint8
-            return .uint8(try decoder.readUInt8())
+    case 0x42:  // 'B' - uint8
+      return .uint8(try decoder.readUInt8())
 
-        case 0x73:  // 's' - int16
-            return .int16(try decoder.readInt16())
+    case 0x73:  // 's' - int16
+      return .int16(try decoder.readInt16())
 
-        case 0x75:  // 'u' - uint16
-            return .uint16(try decoder.readUInt16())
+    case 0x75:  // 'u' - uint16
+      return .uint16(try decoder.readUInt16())
 
-        case 0x49:  // 'I' - int32
-            return .int32(try decoder.readInt32())
+    case 0x49:  // 'I' - int32
+      return .int32(try decoder.readInt32())
 
-        case 0x69:  // 'i' - uint32
-            return .uint32(try decoder.readUInt32())
+    case 0x69:  // 'i' - uint32
+      return .uint32(try decoder.readUInt32())
 
-        case 0x6C:  // 'l' - int64
-            return .int64(try decoder.readInt64())
+    case 0x6C:  // 'l' - int64
+      return .int64(try decoder.readInt64())
 
-        case 0x66:  // 'f' - float
-            return .float(try decoder.readFloat())
+    case 0x66:  // 'f' - float
+      return .float(try decoder.readFloat())
 
-        case 0x64:  // 'd' - double
-            return .double(try decoder.readDouble())
+    case 0x64:  // 'd' - double
+      return .double(try decoder.readDouble())
 
-        case 0x44:  // 'D' - decimal
-            let scale = try decoder.readUInt8()
-            let value = try decoder.readUInt32()
-            return .decimal(scale: scale, value: value)
+    case 0x44:  // 'D' - decimal
+      let scale = try decoder.readUInt8()
+      let value = try decoder.readUInt32()
+      return .decimal(scale: scale, value: value)
 
-        case 0x53:  // 'S' - long string
-            return .string(try decoder.readLongString())
+    case 0x53:  // 'S' - long string
+      return .string(try decoder.readLongString())
 
-        case 0x78:  // 'x' - byte array
-            return .bytes(try decoder.readLongBytes())
+    case 0x78:  // 'x' - byte array
+      return .bytes(try decoder.readLongBytes())
 
-        case 0x41:  // 'A' - array
-            let arrayData = try decoder.readLongBytes()
-            var arrayDecoder = WireDecoder(arrayData)
-            var elements = [FieldValue]()
-            while arrayDecoder.hasMore {
-                elements.append(try FieldValue.decode(from: &arrayDecoder))
-            }
-            return .array(elements)
+    case 0x41:  // 'A' - array
+      let arrayData = try decoder.readLongBytes()
+      var arrayDecoder = WireDecoder(arrayData)
+      var elements = [FieldValue]()
+      while arrayDecoder.hasMore {
+        elements.append(try FieldValue.decode(from: &arrayDecoder))
+      }
+      return .array(elements)
 
-        case 0x54:  // 'T' - timestamp
-            let timestamp = try decoder.readUInt64()
-            return .timestamp(Date(timeIntervalSince1970: TimeInterval(timestamp)))
+    case 0x54:  // 'T' - timestamp
+      let timestamp = try decoder.readUInt64()
+      return .timestamp(Date(timeIntervalSince1970: TimeInterval(timestamp)))
 
-        case 0x46:  // 'F' - table
-            return .table(try decodeTable(from: &decoder))
+    case 0x46:  // 'F' - table
+      return .table(try decodeTable(from: &decoder))
 
-        case 0x56:  // 'V' - void
-            return .void
+    case 0x56:  // 'V' - void
+      return .void
 
-        default:
-            throw WireFormatError.unknownFieldType(typeTag)
-        }
+    default:
+      throw WireFormatError.unknownFieldType(typeTag)
     }
+  }
 }
 
 // MARK: - Table Encoding Helpers
 
 public func encodeTable(_ table: Table, to encoder: inout WireEncoder) throws {
-    var tableEncoder = WireEncoder()
-    for (key, value) in table {
-        try tableEncoder.writeShortString(key)
-        try value.encode(to: &tableEncoder)
-    }
-    encoder.writeLongBytes(tableEncoder.encodedData)
+  var tableEncoder = WireEncoder()
+  for (key, value) in table {
+    try tableEncoder.writeShortString(key)
+    try value.encode(to: &tableEncoder)
+  }
+  encoder.writeLongBytes(tableEncoder.encodedData)
 }
 
 public func encodeTable(_ table: Table) throws -> Data {
-    var encoder = WireEncoder()
-    try encodeTable(table, to: &encoder)
-    return encoder.encodedData
+  var encoder = WireEncoder()
+  try encodeTable(table, to: &encoder)
+  return encoder.encodedData
 }
 
 public func decodeTable(from decoder: inout WireDecoder) throws -> Table {
-    let tableData = try decoder.readLongBytes()
-    var tableDecoder = WireDecoder(tableData)
-    var table = Table()
-    while tableDecoder.hasMore {
-        let key = try tableDecoder.readShortString()
-        let value = try FieldValue.decode(from: &tableDecoder)
-        table[key] = value
-    }
-    return table
+  let tableData = try decoder.readLongBytes()
+  var tableDecoder = WireDecoder(tableData)
+  var table = Table()
+  while tableDecoder.hasMore {
+    let key = try tableDecoder.readShortString()
+    let value = try FieldValue.decode(from: &tableDecoder)
+    table[key] = value
+  }
+  return table
 }
 
 public func decodeTable(from data: Data) throws -> Table {
-    var decoder = WireDecoder(data)
-    return try decodeTable(from: &decoder)
+  var decoder = WireDecoder(data)
+  return try decodeTable(from: &decoder)
 }
 
 // MARK: - Basic Properties
 
 public struct BasicProperties: Sendable, Equatable {
-    public var contentType: String?
-    public var contentEncoding: String?
-    public var headers: Table?
-    public var deliveryMode: DeliveryMode?
-    public var priority: UInt8?
-    public var correlationId: String?
-    public var replyTo: String?
-    public var expiration: String?
-    public var messageId: String?
-    public var timestamp: Date?
-    public var type: String?
-    public var userId: String?
-    public var appId: String?
-    public var clusterId: String?  // deprecated but still in spec
+  public var contentType: String?
+  public var contentEncoding: String?
+  public var headers: Table?
+  public var deliveryMode: DeliveryMode?
+  public var priority: UInt8?
+  public var correlationId: String?
+  public var replyTo: String?
+  public var expiration: String?
+  public var messageId: String?
+  public var timestamp: Date?
+  public var type: String?
+  public var userId: String?
+  public var appId: String?
+  public var clusterId: String?  // deprecated but still in spec
 
-    public init(
-        contentType: String? = nil,
-        contentEncoding: String? = nil,
-        headers: Table? = nil,
-        deliveryMode: DeliveryMode? = nil,
-        priority: UInt8? = nil,
-        correlationId: String? = nil,
-        replyTo: String? = nil,
-        expiration: String? = nil,
-        messageId: String? = nil,
-        timestamp: Date? = nil,
-        type: String? = nil,
-        userId: String? = nil,
-        appId: String? = nil,
-        clusterId: String? = nil
-    ) {
-        self.contentType = contentType
-        self.contentEncoding = contentEncoding
-        self.headers = headers
-        self.deliveryMode = deliveryMode
-        self.priority = priority
-        self.correlationId = correlationId
-        self.replyTo = replyTo
-        self.expiration = expiration
-        self.messageId = messageId
-        self.timestamp = timestamp
-        self.type = type
-        self.userId = userId
-        self.appId = appId
-        self.clusterId = clusterId
-    }
+  public init(
+    contentType: String? = nil,
+    contentEncoding: String? = nil,
+    headers: Table? = nil,
+    deliveryMode: DeliveryMode? = nil,
+    priority: UInt8? = nil,
+    correlationId: String? = nil,
+    replyTo: String? = nil,
+    expiration: String? = nil,
+    messageId: String? = nil,
+    timestamp: Date? = nil,
+    type: String? = nil,
+    userId: String? = nil,
+    appId: String? = nil,
+    clusterId: String? = nil
+  ) {
+    self.contentType = contentType
+    self.contentEncoding = contentEncoding
+    self.headers = headers
+    self.deliveryMode = deliveryMode
+    self.priority = priority
+    self.correlationId = correlationId
+    self.replyTo = replyTo
+    self.expiration = expiration
+    self.messageId = messageId
+    self.timestamp = timestamp
+    self.type = type
+    self.userId = userId
+    self.appId = appId
+    self.clusterId = clusterId
+  }
 
-    /// Persistent message properties (deliveryMode = 2)
-    public static var persistent: BasicProperties {
-        BasicProperties(deliveryMode: .persistent)
-    }
+  /// Persistent message properties (deliveryMode = 2)
+  public static var persistent: BasicProperties {
+    BasicProperties(deliveryMode: .persistent)
+  }
 
-    /// Transient message properties (deliveryMode = 1)
-    public static var transient: BasicProperties {
-        BasicProperties(deliveryMode: .transient)
-    }
+  /// Transient message properties (deliveryMode = 1)
+  public static var transient: BasicProperties {
+    BasicProperties(deliveryMode: .transient)
+  }
 
-    /// Compute property flags for encoding
-    public var propertyFlags: PropertyFlags {
-        var flags = PropertyFlags()
-        if contentType != nil { flags.insert(.contentType) }
-        if contentEncoding != nil { flags.insert(.contentEncoding) }
-        if headers != nil { flags.insert(.headers) }
-        if deliveryMode != nil { flags.insert(.deliveryMode) }
-        if priority != nil { flags.insert(.priority) }
-        if correlationId != nil { flags.insert(.correlationId) }
-        if replyTo != nil { flags.insert(.replyTo) }
-        if expiration != nil { flags.insert(.expiration) }
-        if messageId != nil { flags.insert(.messageId) }
-        if timestamp != nil { flags.insert(.timestamp) }
-        if type != nil { flags.insert(.type) }
-        if userId != nil { flags.insert(.userId) }
-        if appId != nil { flags.insert(.appId) }
-        if clusterId != nil { flags.insert(.clusterId) }
-        return flags
-    }
+  /// Compute property flags for encoding
+  public var propertyFlags: PropertyFlags {
+    var flags = PropertyFlags()
+    if contentType != nil { flags.insert(.contentType) }
+    if contentEncoding != nil { flags.insert(.contentEncoding) }
+    if headers != nil { flags.insert(.headers) }
+    if deliveryMode != nil { flags.insert(.deliveryMode) }
+    if priority != nil { flags.insert(.priority) }
+    if correlationId != nil { flags.insert(.correlationId) }
+    if replyTo != nil { flags.insert(.replyTo) }
+    if expiration != nil { flags.insert(.expiration) }
+    if messageId != nil { flags.insert(.messageId) }
+    if timestamp != nil { flags.insert(.timestamp) }
+    if type != nil { flags.insert(.type) }
+    if userId != nil { flags.insert(.userId) }
+    if appId != nil { flags.insert(.appId) }
+    if clusterId != nil { flags.insert(.clusterId) }
+    return flags
+  }
 }
 
 // MARK: - Basic Properties Encoding
 
 extension BasicProperties {
-    /// Encode properties to wire format
-    public func encode(to encoder: inout WireEncoder) throws {
-        encoder.writeUInt16(propertyFlags.rawValue)
+  /// Encode properties to wire format
+  public func encode(to encoder: inout WireEncoder) throws {
+    encoder.writeUInt16(propertyFlags.rawValue)
 
-        if let v = contentType { try encoder.writeShortString(v) }
-        if let v = contentEncoding { try encoder.writeShortString(v) }
-        if let v = headers { try encodeTable(v, to: &encoder) }
-        if let v = deliveryMode { encoder.writeUInt8(v.rawValue) }
-        if let v = priority { encoder.writeUInt8(v) }
-        if let v = correlationId { try encoder.writeShortString(v) }
-        if let v = replyTo { try encoder.writeShortString(v) }
-        if let v = expiration { try encoder.writeShortString(v) }
-        if let v = messageId { try encoder.writeShortString(v) }
-        if let v = timestamp { encoder.writeUInt64(UInt64(v.timeIntervalSince1970)) }
-        if let v = type { try encoder.writeShortString(v) }
-        if let v = userId { try encoder.writeShortString(v) }
-        if let v = appId { try encoder.writeShortString(v) }
-        if let v = clusterId { try encoder.writeShortString(v) }
+    if let v = contentType { try encoder.writeShortString(v) }
+    if let v = contentEncoding { try encoder.writeShortString(v) }
+    if let v = headers { try encodeTable(v, to: &encoder) }
+    if let v = deliveryMode { encoder.writeUInt8(v.rawValue) }
+    if let v = priority { encoder.writeUInt8(v) }
+    if let v = correlationId { try encoder.writeShortString(v) }
+    if let v = replyTo { try encoder.writeShortString(v) }
+    if let v = expiration { try encoder.writeShortString(v) }
+    if let v = messageId { try encoder.writeShortString(v) }
+    if let v = timestamp { encoder.writeUInt64(UInt64(v.timeIntervalSince1970)) }
+    if let v = type { try encoder.writeShortString(v) }
+    if let v = userId { try encoder.writeShortString(v) }
+    if let v = appId { try encoder.writeShortString(v) }
+    if let v = clusterId { try encoder.writeShortString(v) }
+  }
+
+  /// Decode properties from wire format
+  public static func decode(from decoder: inout WireDecoder) throws -> BasicProperties {
+    let flagsRaw = try decoder.readUInt16()
+    let flags = PropertyFlags(rawValue: flagsRaw)
+
+    var props = BasicProperties()
+
+    if flags.contains(.contentType) {
+      props.contentType = try decoder.readShortString()
+    }
+    if flags.contains(.contentEncoding) {
+      props.contentEncoding = try decoder.readShortString()
+    }
+    if flags.contains(.headers) {
+      props.headers = try decodeTable(from: &decoder)
+    }
+    if flags.contains(.deliveryMode) {
+      let mode = try decoder.readUInt8()
+      props.deliveryMode = DeliveryMode(rawValue: mode)
+    }
+    if flags.contains(.priority) {
+      props.priority = try decoder.readUInt8()
+    }
+    if flags.contains(.correlationId) {
+      props.correlationId = try decoder.readShortString()
+    }
+    if flags.contains(.replyTo) {
+      props.replyTo = try decoder.readShortString()
+    }
+    if flags.contains(.expiration) {
+      props.expiration = try decoder.readShortString()
+    }
+    if flags.contains(.messageId) {
+      props.messageId = try decoder.readShortString()
+    }
+    if flags.contains(.timestamp) {
+      let ts = try decoder.readUInt64()
+      props.timestamp = Date(timeIntervalSince1970: TimeInterval(ts))
+    }
+    if flags.contains(.type) {
+      props.type = try decoder.readShortString()
+    }
+    if flags.contains(.userId) {
+      props.userId = try decoder.readShortString()
+    }
+    if flags.contains(.appId) {
+      props.appId = try decoder.readShortString()
+    }
+    if flags.contains(.clusterId) {
+      props.clusterId = try decoder.readShortString()
     }
 
-    /// Decode properties from wire format
-    public static func decode(from decoder: inout WireDecoder) throws -> BasicProperties {
-        let flagsRaw = try decoder.readUInt16()
-        let flags = PropertyFlags(rawValue: flagsRaw)
-
-        var props = BasicProperties()
-
-        if flags.contains(.contentType) {
-            props.contentType = try decoder.readShortString()
-        }
-        if flags.contains(.contentEncoding) {
-            props.contentEncoding = try decoder.readShortString()
-        }
-        if flags.contains(.headers) {
-            props.headers = try decodeTable(from: &decoder)
-        }
-        if flags.contains(.deliveryMode) {
-            let mode = try decoder.readUInt8()
-            props.deliveryMode = DeliveryMode(rawValue: mode)
-        }
-        if flags.contains(.priority) {
-            props.priority = try decoder.readUInt8()
-        }
-        if flags.contains(.correlationId) {
-            props.correlationId = try decoder.readShortString()
-        }
-        if flags.contains(.replyTo) {
-            props.replyTo = try decoder.readShortString()
-        }
-        if flags.contains(.expiration) {
-            props.expiration = try decoder.readShortString()
-        }
-        if flags.contains(.messageId) {
-            props.messageId = try decoder.readShortString()
-        }
-        if flags.contains(.timestamp) {
-            let ts = try decoder.readUInt64()
-            props.timestamp = Date(timeIntervalSince1970: TimeInterval(ts))
-        }
-        if flags.contains(.type) {
-            props.type = try decoder.readShortString()
-        }
-        if flags.contains(.userId) {
-            props.userId = try decoder.readShortString()
-        }
-        if flags.contains(.appId) {
-            props.appId = try decoder.readShortString()
-        }
-        if flags.contains(.clusterId) {
-            props.clusterId = try decoder.readShortString()
-        }
-
-        return props
-    }
+    return props
+  }
 }
 
 // MARK: - Fluent Builders
 
 extension BasicProperties {
-    public func withContentType(_ value: String) -> BasicProperties {
-        var copy = self
-        copy.contentType = value
-        return copy
-    }
+  public func withContentType(_ value: String) -> BasicProperties {
+    var copy = self
+    copy.contentType = value
+    return copy
+  }
 
-    public func withContentEncoding(_ value: String) -> BasicProperties {
-        var copy = self
-        copy.contentEncoding = value
-        return copy
-    }
+  public func withContentEncoding(_ value: String) -> BasicProperties {
+    var copy = self
+    copy.contentEncoding = value
+    return copy
+  }
 
-    public func withHeaders(_ value: Table) -> BasicProperties {
-        var copy = self
-        copy.headers = value
-        return copy
-    }
+  public func withHeaders(_ value: Table) -> BasicProperties {
+    var copy = self
+    copy.headers = value
+    return copy
+  }
 
-    public func withDeliveryMode(_ value: DeliveryMode) -> BasicProperties {
-        var copy = self
-        copy.deliveryMode = value
-        return copy
-    }
+  public func withDeliveryMode(_ value: DeliveryMode) -> BasicProperties {
+    var copy = self
+    copy.deliveryMode = value
+    return copy
+  }
 
-    public func withPriority(_ value: UInt8) -> BasicProperties {
-        var copy = self
-        copy.priority = value
-        return copy
-    }
+  public func withPriority(_ value: UInt8) -> BasicProperties {
+    var copy = self
+    copy.priority = value
+    return copy
+  }
 
-    public func withCorrelationId(_ value: String) -> BasicProperties {
-        var copy = self
-        copy.correlationId = value
-        return copy
-    }
+  public func withCorrelationId(_ value: String) -> BasicProperties {
+    var copy = self
+    copy.correlationId = value
+    return copy
+  }
 
-    public func withReplyTo(_ value: String) -> BasicProperties {
-        var copy = self
-        copy.replyTo = value
-        return copy
-    }
+  public func withReplyTo(_ value: String) -> BasicProperties {
+    var copy = self
+    copy.replyTo = value
+    return copy
+  }
 
-    /// TTL in milliseconds as string
-    public func withExpiration(_ value: String) -> BasicProperties {
-        var copy = self
-        copy.expiration = value
-        return copy
-    }
+  /// TTL in milliseconds as string
+  public func withExpiration(_ value: String) -> BasicProperties {
+    var copy = self
+    copy.expiration = value
+    return copy
+  }
 
-    /// TTL in milliseconds (AMQP 0-9-1 requires string encoding)
-    public func withExpiration(milliseconds: Int) -> BasicProperties {
-        withExpiration(String(milliseconds))
-    }
+  /// TTL in milliseconds (AMQP 0-9-1 requires string encoding)
+  public func withExpiration(milliseconds: Int) -> BasicProperties {
+    withExpiration(String(milliseconds))
+  }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-    public func withExpiration(_ duration: Duration) -> BasicProperties {
-        let milliseconds = Int64(duration.components.seconds) * 1000 +
-                          Int64(duration.components.attoseconds) / 1_000_000_000_000_000
-        return withExpiration(String(milliseconds))
-    }
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  public func withExpiration(_ duration: Duration) -> BasicProperties {
+    let milliseconds =
+      Int64(duration.components.seconds) * 1000 + Int64(duration.components.attoseconds)
+      / 1_000_000_000_000_000
+    return withExpiration(String(milliseconds))
+  }
 
-    public func withMessageId(_ value: String) -> BasicProperties {
-        var copy = self
-        copy.messageId = value
-        return copy
-    }
+  public func withMessageId(_ value: String) -> BasicProperties {
+    var copy = self
+    copy.messageId = value
+    return copy
+  }
 
-    public func withTimestamp(_ value: Date) -> BasicProperties {
-        var copy = self
-        copy.timestamp = value
-        return copy
-    }
+  public func withTimestamp(_ value: Date) -> BasicProperties {
+    var copy = self
+    copy.timestamp = value
+    return copy
+  }
 
-    public func withType(_ value: String) -> BasicProperties {
-        var copy = self
-        copy.type = value
-        return copy
-    }
+  public func withType(_ value: String) -> BasicProperties {
+    var copy = self
+    copy.type = value
+    return copy
+  }
 
-    public func withUserId(_ value: String) -> BasicProperties {
-        var copy = self
-        copy.userId = value
-        return copy
-    }
+  public func withUserId(_ value: String) -> BasicProperties {
+    var copy = self
+    copy.userId = value
+    return copy
+  }
 
-    public func withAppId(_ value: String) -> BasicProperties {
-        var copy = self
-        copy.appId = value
-        return copy
-    }
+  public func withAppId(_ value: String) -> BasicProperties {
+    var copy = self
+    copy.appId = value
+    return copy
+  }
 }

--- a/Sources/AMQPProtocol/WireFormat.swift
+++ b/Sources/AMQPProtocol/WireFormat.swift
@@ -15,140 +15,140 @@ import Foundation
 /// Encodes values into AMQP wire format (big-endian).
 /// Not Sendable: has mutating methods for sequential encoding.
 public struct WireEncoder {
-    private var data: Data
+  private var data: Data
 
-    public init(capacity: Int = 256) {
-        self.data = Data()
-        self.data.reserveCapacity(capacity)
+  public init(capacity: Int = 256) {
+    self.data = Data()
+    self.data.reserveCapacity(capacity)
+  }
+
+  /// Get the encoded data
+  public var encodedData: Data {
+    data
+  }
+
+  /// Current size of encoded data
+  public var count: Int {
+    data.count
+  }
+
+  // MARK: - Primitive Types
+
+  /// Write a single byte
+  public mutating func writeUInt8(_ value: UInt8) {
+    data.append(value)
+  }
+
+  /// Write a signed byte
+  public mutating func writeInt8(_ value: Int8) {
+    data.append(UInt8(bitPattern: value))
+  }
+
+  /// Write a 16-bit unsigned integer (big-endian)
+  public mutating func writeUInt16(_ value: UInt16) {
+    data.append(UInt8(value >> 8))
+    data.append(UInt8(value & 0xFF))
+  }
+
+  /// Write a 16-bit signed integer (big-endian)
+  public mutating func writeInt16(_ value: Int16) {
+    writeUInt16(UInt16(bitPattern: value))
+  }
+
+  /// Write a 32-bit unsigned integer (big-endian)
+  public mutating func writeUInt32(_ value: UInt32) {
+    data.append(UInt8((value >> 24) & 0xFF))
+    data.append(UInt8((value >> 16) & 0xFF))
+    data.append(UInt8((value >> 8) & 0xFF))
+    data.append(UInt8(value & 0xFF))
+  }
+
+  /// Write a 32-bit signed integer (big-endian)
+  public mutating func writeInt32(_ value: Int32) {
+    writeUInt32(UInt32(bitPattern: value))
+  }
+
+  /// Write a 64-bit unsigned integer (big-endian)
+  public mutating func writeUInt64(_ value: UInt64) {
+    data.append(UInt8((value >> 56) & 0xFF))
+    data.append(UInt8((value >> 48) & 0xFF))
+    data.append(UInt8((value >> 40) & 0xFF))
+    data.append(UInt8((value >> 32) & 0xFF))
+    data.append(UInt8((value >> 24) & 0xFF))
+    data.append(UInt8((value >> 16) & 0xFF))
+    data.append(UInt8((value >> 8) & 0xFF))
+    data.append(UInt8(value & 0xFF))
+  }
+
+  /// Write a 64-bit signed integer (big-endian)
+  public mutating func writeInt64(_ value: Int64) {
+    writeUInt64(UInt64(bitPattern: value))
+  }
+
+  /// Write a 32-bit float (big-endian IEEE 754)
+  public mutating func writeFloat(_ value: Float) {
+    writeUInt32(value.bitPattern)
+  }
+
+  /// Write a 64-bit double (big-endian IEEE 754)
+  public mutating func writeDouble(_ value: Double) {
+    writeUInt64(value.bitPattern)
+  }
+
+  // MARK: - AMQP String Types
+
+  /// Write a short string (max 255 bytes)
+  /// Format: [length:1][data:length]
+  public mutating func writeShortString(_ value: String) throws {
+    let bytes = Data(value.utf8)
+    guard bytes.count <= 255 else {
+      throw WireFormatError.stringTooLong(length: bytes.count, maxLength: 255)
     }
+    writeUInt8(UInt8(bytes.count))
+    data.append(bytes)
+  }
 
-    /// Get the encoded data
-    public var encodedData: Data {
-        data
-    }
+  /// Write a long string (up to 4GB)
+  /// Format: [length:4][data:length]
+  public mutating func writeLongString(_ value: String) {
+    let bytes = Data(value.utf8)
+    writeUInt32(UInt32(bytes.count))
+    data.append(bytes)
+  }
 
-    /// Current size of encoded data
-    public var count: Int {
-        data.count
-    }
+  /// Write raw bytes with a 32-bit length prefix
+  public mutating func writeLongBytes(_ value: Data) {
+    writeUInt32(UInt32(value.count))
+    data.append(value)
+  }
 
-    // MARK: - Primitive Types
+  /// Write raw bytes without length prefix
+  public mutating func writeBytes(_ value: Data) {
+    data.append(value)
+  }
 
-    /// Write a single byte
-    public mutating func writeUInt8(_ value: UInt8) {
-        data.append(value)
-    }
+  // MARK: - Bit Packing
 
-    /// Write a signed byte
-    public mutating func writeInt8(_ value: Int8) {
-        data.append(UInt8(bitPattern: value))
-    }
-
-    /// Write a 16-bit unsigned integer (big-endian)
-    public mutating func writeUInt16(_ value: UInt16) {
-        data.append(UInt8(value >> 8))
-        data.append(UInt8(value & 0xFF))
-    }
-
-    /// Write a 16-bit signed integer (big-endian)
-    public mutating func writeInt16(_ value: Int16) {
-        writeUInt16(UInt16(bitPattern: value))
-    }
-
-    /// Write a 32-bit unsigned integer (big-endian)
-    public mutating func writeUInt32(_ value: UInt32) {
-        data.append(UInt8((value >> 24) & 0xFF))
-        data.append(UInt8((value >> 16) & 0xFF))
-        data.append(UInt8((value >> 8) & 0xFF))
-        data.append(UInt8(value & 0xFF))
-    }
-
-    /// Write a 32-bit signed integer (big-endian)
-    public mutating func writeInt32(_ value: Int32) {
-        writeUInt32(UInt32(bitPattern: value))
-    }
-
-    /// Write a 64-bit unsigned integer (big-endian)
-    public mutating func writeUInt64(_ value: UInt64) {
-        data.append(UInt8((value >> 56) & 0xFF))
-        data.append(UInt8((value >> 48) & 0xFF))
-        data.append(UInt8((value >> 40) & 0xFF))
-        data.append(UInt8((value >> 32) & 0xFF))
-        data.append(UInt8((value >> 24) & 0xFF))
-        data.append(UInt8((value >> 16) & 0xFF))
-        data.append(UInt8((value >> 8) & 0xFF))
-        data.append(UInt8(value & 0xFF))
-    }
-
-    /// Write a 64-bit signed integer (big-endian)
-    public mutating func writeInt64(_ value: Int64) {
-        writeUInt64(UInt64(bitPattern: value))
-    }
-
-    /// Write a 32-bit float (big-endian IEEE 754)
-    public mutating func writeFloat(_ value: Float) {
-        writeUInt32(value.bitPattern)
-    }
-
-    /// Write a 64-bit double (big-endian IEEE 754)
-    public mutating func writeDouble(_ value: Double) {
-        writeUInt64(value.bitPattern)
-    }
-
-    // MARK: - AMQP String Types
-
-    /// Write a short string (max 255 bytes)
-    /// Format: [length:1][data:length]
-    public mutating func writeShortString(_ value: String) throws {
-        let bytes = Data(value.utf8)
-        guard bytes.count <= 255 else {
-            throw WireFormatError.stringTooLong(length: bytes.count, maxLength: 255)
+  /// Write packed boolean flags (up to 8 flags per byte)
+  public mutating func writeBits(_ flags: [Bool]) {
+    var byteIndex = 0
+    while byteIndex * 8 < flags.count {
+      var byte: UInt8 = 0
+      for bitIndex in 0..<8 {
+        let flagIndex = byteIndex * 8 + bitIndex
+        if flagIndex < flags.count && flags[flagIndex] {
+          byte |= UInt8(1 << bitIndex)
         }
-        writeUInt8(UInt8(bytes.count))
-        data.append(bytes)
+      }
+      writeUInt8(byte)
+      byteIndex += 1
     }
+  }
 
-    /// Write a long string (up to 4GB)
-    /// Format: [length:4][data:length]
-    public mutating func writeLongString(_ value: String) {
-        let bytes = Data(value.utf8)
-        writeUInt32(UInt32(bytes.count))
-        data.append(bytes)
-    }
-
-    /// Write raw bytes with a 32-bit length prefix
-    public mutating func writeLongBytes(_ value: Data) {
-        writeUInt32(UInt32(value.count))
-        data.append(value)
-    }
-
-    /// Write raw bytes without length prefix
-    public mutating func writeBytes(_ value: Data) {
-        data.append(value)
-    }
-
-    // MARK: - Bit Packing
-
-    /// Write packed boolean flags (up to 8 flags per byte)
-    public mutating func writeBits(_ flags: [Bool]) {
-        var byteIndex = 0
-        while byteIndex * 8 < flags.count {
-            var byte: UInt8 = 0
-            for bitIndex in 0..<8 {
-                let flagIndex = byteIndex * 8 + bitIndex
-                if flagIndex < flags.count && flags[flagIndex] {
-                    byte |= UInt8(1 << bitIndex)
-                }
-            }
-            writeUInt8(byte)
-            byteIndex += 1
-        }
-    }
-
-    /// Write a single boolean as a byte
-    public mutating func writeBoolean(_ value: Bool) {
-        writeUInt8(value ? 1 : 0)
-    }
+  /// Write a single boolean as a byte
+  public mutating func writeBoolean(_ value: Bool) {
+    writeUInt8(value ? 1 : 0)
+  }
 }
 
 // MARK: - Wire Format Decoder
@@ -156,247 +156,244 @@ public struct WireEncoder {
 /// Decodes values from AMQP wire format (big-endian).
 /// Not Sendable: has mutating methods for sequential decoding.
 public struct WireDecoder {
-    private let data: Data
-    private var offset: Int
+  private let data: Data
+  private var offset: Int
 
-    public init(_ data: Data) {
-        self.data = data
-        self.offset = 0
+  public init(_ data: Data) {
+    self.data = data
+    self.offset = 0
+  }
+
+  /// Current read position
+  public var position: Int {
+    offset
+  }
+
+  /// Bytes remaining to read
+  public var remaining: Int {
+    data.count - offset
+  }
+
+  /// Check if there's more data to read
+  public var hasMore: Bool {
+    offset < data.count
+  }
+
+  // MARK: - Primitive Types
+
+  /// Read a single byte
+  public mutating func readUInt8() throws -> UInt8 {
+    guard remaining >= 1 else {
+      throw WireFormatError.insufficientData(needed: 1, available: remaining)
+    }
+    let value = data[data.startIndex + offset]
+    offset += 1
+    return value
+  }
+
+  /// Read a signed byte
+  public mutating func readInt8() throws -> Int8 {
+    Int8(bitPattern: try readUInt8())
+  }
+
+  /// Read a 16-bit unsigned integer (big-endian)
+  public mutating func readUInt16() throws -> UInt16 {
+    guard remaining >= 2 else {
+      throw WireFormatError.insufficientData(needed: 2, available: remaining)
+    }
+    let start = data.startIndex + offset
+    let value = (UInt16(data[start]) << 8) | UInt16(data[start + 1])
+    offset += 2
+    return value
+  }
+
+  /// Read a 16-bit signed integer (big-endian)
+  public mutating func readInt16() throws -> Int16 {
+    Int16(bitPattern: try readUInt16())
+  }
+
+  /// Read a 32-bit unsigned integer (big-endian)
+  public mutating func readUInt32() throws -> UInt32 {
+    guard remaining >= 4 else {
+      throw WireFormatError.insufficientData(needed: 4, available: remaining)
+    }
+    let start = data.startIndex + offset
+    let value =
+      (UInt32(data[start]) << 24) | (UInt32(data[start + 1]) << 16) | (UInt32(data[start + 2]) << 8)
+      | UInt32(data[start + 3])
+    offset += 4
+    return value
+  }
+
+  /// Read a 32-bit signed integer (big-endian)
+  public mutating func readInt32() throws -> Int32 {
+    Int32(bitPattern: try readUInt32())
+  }
+
+  /// Read a 64-bit unsigned integer (big-endian)
+  public mutating func readUInt64() throws -> UInt64 {
+    guard remaining >= 8 else {
+      throw WireFormatError.insufficientData(needed: 8, available: remaining)
+    }
+    let start = data.startIndex + offset
+    let high: UInt64 =
+      (UInt64(data[start]) << 56) | (UInt64(data[start + 1]) << 48)
+      | (UInt64(data[start + 2]) << 40) | (UInt64(data[start + 3]) << 32)
+    let low: UInt64 =
+      (UInt64(data[start + 4]) << 24) | (UInt64(data[start + 5]) << 16)
+      | (UInt64(data[start + 6]) << 8) | UInt64(data[start + 7])
+    offset += 8
+    return high | low
+  }
+
+  /// Read a 64-bit signed integer (big-endian)
+  public mutating func readInt64() throws -> Int64 {
+    Int64(bitPattern: try readUInt64())
+  }
+
+  /// Read a 32-bit float (big-endian IEEE 754)
+  public mutating func readFloat() throws -> Float {
+    Float(bitPattern: try readUInt32())
+  }
+
+  /// Read a 64-bit double (big-endian IEEE 754)
+  public mutating func readDouble() throws -> Double {
+    Double(bitPattern: try readUInt64())
+  }
+
+  // MARK: - AMQP String Types
+
+  /// Read a short string (max 255 bytes)
+  /// Format: [length:1][data:length]
+  public mutating func readShortString() throws -> String {
+    let length = Int(try readUInt8())
+    guard remaining >= length else {
+      throw WireFormatError.insufficientData(needed: length, available: remaining)
+    }
+    let start = data.startIndex + offset
+    let bytes = data[start..<start + length]
+    offset += length
+    guard let string = String(data: bytes, encoding: .utf8) else {
+      throw WireFormatError.invalidUTF8
+    }
+    return string
+  }
+
+  /// Read a long string
+  /// Format: [length:4][data:length]
+  public mutating func readLongString() throws -> String {
+    let length = Int(try readUInt32())
+    guard remaining >= length else {
+      throw WireFormatError.insufficientData(needed: length, available: remaining)
+    }
+    let start = data.startIndex + offset
+    let bytes = data[start..<start + length]
+    offset += length
+    guard let string = String(data: bytes, encoding: .utf8) else {
+      throw WireFormatError.invalidUTF8
+    }
+    return string
+  }
+
+  /// Read raw bytes with a 32-bit length prefix
+  public mutating func readLongBytes() throws -> Data {
+    let length = Int(try readUInt32())
+    guard remaining >= length else {
+      throw WireFormatError.insufficientData(needed: length, available: remaining)
+    }
+    let start = data.startIndex + offset
+    let bytes = data[start..<start + length]
+    offset += length
+    return Data(bytes)
+  }
+
+  /// Read a specific number of raw bytes
+  public mutating func readBytes(_ count: Int) throws -> Data {
+    guard remaining >= count else {
+      throw WireFormatError.insufficientData(needed: count, available: remaining)
+    }
+    let start = data.startIndex + offset
+    let bytes = data[start..<start + count]
+    offset += count
+    return Data(bytes)
+  }
+
+  /// Skip a number of bytes
+  public mutating func skip(_ count: Int) throws {
+    guard remaining >= count else {
+      throw WireFormatError.insufficientData(needed: count, available: remaining)
+    }
+    offset += count
+  }
+
+  // MARK: - Bit Unpacking
+
+  /// Read packed boolean flags
+  public mutating func readBits(_ count: Int) throws -> [Bool] {
+    let byteCount = (count + 7) / 8
+    guard remaining >= byteCount else {
+      throw WireFormatError.insufficientData(needed: byteCount, available: remaining)
     }
 
-    /// Current read position
-    public var position: Int {
-        offset
-    }
+    var flags = [Bool]()
+    flags.reserveCapacity(count)
 
-    /// Bytes remaining to read
-    public var remaining: Int {
-        data.count - offset
-    }
-
-    /// Check if there's more data to read
-    public var hasMore: Bool {
-        offset < data.count
-    }
-
-    // MARK: - Primitive Types
-
-    /// Read a single byte
-    public mutating func readUInt8() throws -> UInt8 {
-        guard remaining >= 1 else {
-            throw WireFormatError.insufficientData(needed: 1, available: remaining)
+    for byteIndex in 0..<byteCount {
+      let byte = try readUInt8()
+      for bitIndex in 0..<8 {
+        let flagIndex = byteIndex * 8 + bitIndex
+        if flagIndex < count {
+          flags.append((byte & (1 << bitIndex)) != 0)
         }
-        let value = data[data.startIndex + offset]
-        offset += 1
-        return value
+      }
     }
 
-    /// Read a signed byte
-    public mutating func readInt8() throws -> Int8 {
-        Int8(bitPattern: try readUInt8())
+    return flags
+  }
+
+  /// Read a single boolean
+  public mutating func readBoolean() throws -> Bool {
+    try readUInt8() != 0
+  }
+
+  // MARK: - Peek Operations
+
+  /// Peek at a byte without advancing the position
+  public func peekUInt8() throws -> UInt8 {
+    guard remaining >= 1 else {
+      throw WireFormatError.insufficientData(needed: 1, available: remaining)
     }
+    return data[data.startIndex + offset]
+  }
 
-    /// Read a 16-bit unsigned integer (big-endian)
-    public mutating func readUInt16() throws -> UInt16 {
-        guard remaining >= 2 else {
-            throw WireFormatError.insufficientData(needed: 2, available: remaining)
-        }
-        let start = data.startIndex + offset
-        let value = (UInt16(data[start]) << 8) | UInt16(data[start + 1])
-        offset += 2
-        return value
+  /// Peek at multiple bytes without advancing the position
+  public func peekBytes(_ count: Int) throws -> Data {
+    guard remaining >= count else {
+      throw WireFormatError.insufficientData(needed: count, available: remaining)
     }
-
-    /// Read a 16-bit signed integer (big-endian)
-    public mutating func readInt16() throws -> Int16 {
-        Int16(bitPattern: try readUInt16())
-    }
-
-    /// Read a 32-bit unsigned integer (big-endian)
-    public mutating func readUInt32() throws -> UInt32 {
-        guard remaining >= 4 else {
-            throw WireFormatError.insufficientData(needed: 4, available: remaining)
-        }
-        let start = data.startIndex + offset
-        let value = (UInt32(data[start]) << 24) |
-                    (UInt32(data[start + 1]) << 16) |
-                    (UInt32(data[start + 2]) << 8) |
-                    UInt32(data[start + 3])
-        offset += 4
-        return value
-    }
-
-    /// Read a 32-bit signed integer (big-endian)
-    public mutating func readInt32() throws -> Int32 {
-        Int32(bitPattern: try readUInt32())
-    }
-
-    /// Read a 64-bit unsigned integer (big-endian)
-    public mutating func readUInt64() throws -> UInt64 {
-        guard remaining >= 8 else {
-            throw WireFormatError.insufficientData(needed: 8, available: remaining)
-        }
-        let start = data.startIndex + offset
-        let high: UInt64 = (UInt64(data[start]) << 56) |
-                           (UInt64(data[start + 1]) << 48) |
-                           (UInt64(data[start + 2]) << 40) |
-                           (UInt64(data[start + 3]) << 32)
-        let low: UInt64 = (UInt64(data[start + 4]) << 24) |
-                          (UInt64(data[start + 5]) << 16) |
-                          (UInt64(data[start + 6]) << 8) |
-                          UInt64(data[start + 7])
-        offset += 8
-        return high | low
-    }
-
-    /// Read a 64-bit signed integer (big-endian)
-    public mutating func readInt64() throws -> Int64 {
-        Int64(bitPattern: try readUInt64())
-    }
-
-    /// Read a 32-bit float (big-endian IEEE 754)
-    public mutating func readFloat() throws -> Float {
-        Float(bitPattern: try readUInt32())
-    }
-
-    /// Read a 64-bit double (big-endian IEEE 754)
-    public mutating func readDouble() throws -> Double {
-        Double(bitPattern: try readUInt64())
-    }
-
-    // MARK: - AMQP String Types
-
-    /// Read a short string (max 255 bytes)
-    /// Format: [length:1][data:length]
-    public mutating func readShortString() throws -> String {
-        let length = Int(try readUInt8())
-        guard remaining >= length else {
-            throw WireFormatError.insufficientData(needed: length, available: remaining)
-        }
-        let start = data.startIndex + offset
-        let bytes = data[start..<start + length]
-        offset += length
-        guard let string = String(data: bytes, encoding: .utf8) else {
-            throw WireFormatError.invalidUTF8
-        }
-        return string
-    }
-
-    /// Read a long string
-    /// Format: [length:4][data:length]
-    public mutating func readLongString() throws -> String {
-        let length = Int(try readUInt32())
-        guard remaining >= length else {
-            throw WireFormatError.insufficientData(needed: length, available: remaining)
-        }
-        let start = data.startIndex + offset
-        let bytes = data[start..<start + length]
-        offset += length
-        guard let string = String(data: bytes, encoding: .utf8) else {
-            throw WireFormatError.invalidUTF8
-        }
-        return string
-    }
-
-    /// Read raw bytes with a 32-bit length prefix
-    public mutating func readLongBytes() throws -> Data {
-        let length = Int(try readUInt32())
-        guard remaining >= length else {
-            throw WireFormatError.insufficientData(needed: length, available: remaining)
-        }
-        let start = data.startIndex + offset
-        let bytes = data[start..<start + length]
-        offset += length
-        return Data(bytes)
-    }
-
-    /// Read a specific number of raw bytes
-    public mutating func readBytes(_ count: Int) throws -> Data {
-        guard remaining >= count else {
-            throw WireFormatError.insufficientData(needed: count, available: remaining)
-        }
-        let start = data.startIndex + offset
-        let bytes = data[start..<start + count]
-        offset += count
-        return Data(bytes)
-    }
-
-    /// Skip a number of bytes
-    public mutating func skip(_ count: Int) throws {
-        guard remaining >= count else {
-            throw WireFormatError.insufficientData(needed: count, available: remaining)
-        }
-        offset += count
-    }
-
-    // MARK: - Bit Unpacking
-
-    /// Read packed boolean flags
-    public mutating func readBits(_ count: Int) throws -> [Bool] {
-        let byteCount = (count + 7) / 8
-        guard remaining >= byteCount else {
-            throw WireFormatError.insufficientData(needed: byteCount, available: remaining)
-        }
-
-        var flags = [Bool]()
-        flags.reserveCapacity(count)
-
-        for byteIndex in 0..<byteCount {
-            let byte = try readUInt8()
-            for bitIndex in 0..<8 {
-                let flagIndex = byteIndex * 8 + bitIndex
-                if flagIndex < count {
-                    flags.append((byte & (1 << bitIndex)) != 0)
-                }
-            }
-        }
-
-        return flags
-    }
-
-    /// Read a single boolean
-    public mutating func readBoolean() throws -> Bool {
-        try readUInt8() != 0
-    }
-
-    // MARK: - Peek Operations
-
-    /// Peek at a byte without advancing the position
-    public func peekUInt8() throws -> UInt8 {
-        guard remaining >= 1 else {
-            throw WireFormatError.insufficientData(needed: 1, available: remaining)
-        }
-        return data[data.startIndex + offset]
-    }
-
-    /// Peek at multiple bytes without advancing the position
-    public func peekBytes(_ count: Int) throws -> Data {
-        guard remaining >= count else {
-            throw WireFormatError.insufficientData(needed: count, available: remaining)
-        }
-        let start = data.startIndex + offset
-        return Data(data[start..<start + count])
-    }
+    let start = data.startIndex + offset
+    return Data(data[start..<start + count])
+  }
 }
 
 // MARK: - Wire Format Errors
 
 /// Errors that can occur during wire format encoding/decoding
 public enum WireFormatError: Error, Sendable, Equatable {
-    case insufficientData(needed: Int, available: Int)
-    case stringTooLong(length: Int, maxLength: Int)
-    case invalidUTF8
-    case invalidFrameEnd(expected: UInt8, actual: UInt8)
-    case unknownFrameType(UInt8)
-    case unknownFieldType(UInt8)
-    case frameTooLarge(size: UInt32, maxSize: UInt32)
+  case insufficientData(needed: Int, available: Int)
+  case stringTooLong(length: Int, maxLength: Int)
+  case invalidUTF8
+  case invalidFrameEnd(expected: UInt8, actual: UInt8)
+  case unknownFrameType(UInt8)
+  case unknownFieldType(UInt8)
+  case frameTooLarge(size: UInt32, maxSize: UInt32)
 }
 
 // MARK: - Convenience Extensions
 
 extension Data {
-    /// Create a WireDecoder for this data
-    public func wireDecoder() -> WireDecoder {
-        WireDecoder(self)
-    }
+  /// Create a WireDecoder for this data
+  public func wireDecoder() -> WireDecoder {
+    WireDecoder(self)
+  }
 }

--- a/Sources/BunnySwift/Channel.swift
+++ b/Sources/BunnySwift/Channel.swift
@@ -5,906 +5,922 @@
 //
 // Copyright (c) 2025-2026 Michael S. Klishin
 
+@_exported import AMQPProtocol
 import Foundation
 import NIO
-@_exported import AMQPProtocol
 @_exported import Transport
 
 /// Type alias to disambiguate from Objective-C Method
 public typealias AMQPMethod = AMQPProtocol.Method
 
 public actor Channel {
-    private weak var connection: Connection?
-    private let channelID: UInt16
-    private var isOpen = false
-    private var confirmMode = false
-    private var transactionMode = false
+  private weak var connection: Connection?
+  private let channelID: UInt16
+  private var isOpen = false
+  private var confirmMode = false
+  private var transactionMode = false
 
-    // Pending RPC responses
-    private var pendingResponses: [CheckedContinuation<AMQPMethod, Error>] = []
-    private var pendingGetResponses: [CheckedContinuation<GetResponse?, Error>] = []
+  // Pending RPC responses
+  private var pendingResponses: [CheckedContinuation<AMQPMethod, Error>] = []
+  private var pendingGetResponses: [CheckedContinuation<GetResponse?, Error>] = []
 
-    // Message assembly
-    private var incomingMessage: IncomingMessage?
+  // Message assembly
+  private var incomingMessage: IncomingMessage?
 
-    // Consumers
-    private var consumers: [String: AsyncStream<Message>.Continuation] = [:]
-    private var returnHandlers: [@Sendable (ReturnedMessage) -> Void] = []
+  // Consumers
+  private var consumers: [String: AsyncStream<Message>.Continuation] = [:]
+  private var returnHandlers: [@Sendable (ReturnedMessage) -> Void] = []
 
-    // Channel close event handlers
-    private var closeHandlers: [@Sendable (ChannelCloseInfo) -> Void] = []
+  // Channel close event handlers
+  private var closeHandlers: [@Sendable (ChannelCloseInfo) -> Void] = []
 
-    // Publisher confirms
-    private var nextPublishSeqNo: UInt64 = 1
-    private var confirmHandlers: [UInt64: CheckedContinuation<Bool, Error>] = [:]
-    private var publisherConfirmationTracking = false
-    private var outstandingConfirmsLimit: Int = 0
-    private var outstandingConfirmsCount: Int = 0
-    private var confirmLimitWaiters: [CheckedContinuation<Void, Never>] = []
+  // Publisher confirms
+  private var nextPublishSeqNo: UInt64 = 1
+  private var confirmHandlers: [UInt64: CheckedContinuation<Bool, Error>] = [:]
+  private var publisherConfirmationTracking = false
+  private var outstandingConfirmsLimit: Int = 0
+  private var outstandingConfirmsCount: Int = 0
+  private var confirmLimitWaiters: [CheckedContinuation<Void, Never>] = []
 
-    // MARK: - Initialization
+  // MARK: - Initialization
 
-    internal init(connection: Connection, channelID: UInt16) {
-        self.connection = connection
-        self.channelID = channelID
+  internal init(connection: Connection, channelID: UInt16) {
+    self.connection = connection
+    self.channelID = channelID
+  }
+
+  internal func open() async throws {
+    try await sendMethod(.channelOpen(ChannelOpen()))
+    let response = try await waitForResponse()
+    guard case .channelOpenOk = response else {
+      throw ConnectionError.protocolError("Expected Channel.OpenOk, got \(response)")
+    }
+    isOpen = true
+  }
+
+  // MARK: - Exchange Operations
+
+  public func exchange(
+    _ name: String,
+    type: ExchangeType,
+    durable: Bool = false,
+    autoDelete: Bool = false,
+    internal: Bool = false,
+    arguments: Table = [:]
+  ) async throws -> Exchange {
+    let declare = ExchangeDeclare(
+      reserved1: 0,
+      exchange: name,
+      type: type.rawValue,
+      passive: false,
+      durable: durable,
+      autoDelete: autoDelete,
+      internal: `internal`,
+      noWait: false,
+      arguments: arguments
+    )
+    try await sendMethod(.exchangeDeclare(declare))
+    let response = try await waitForResponse()
+    guard case .exchangeDeclareOk = response else {
+      throw ConnectionError.protocolError("Expected Exchange.DeclareOk, got \(response)")
+    }
+    return Exchange(channel: self, name: name, type: type)
+  }
+
+  public func direct(_ name: String, durable: Bool = false, autoDelete: Bool = false) async throws
+    -> Exchange
+  {
+    try await exchange(name, type: .direct, durable: durable, autoDelete: autoDelete)
+  }
+
+  public func fanout(_ name: String, durable: Bool = false, autoDelete: Bool = false) async throws
+    -> Exchange
+  {
+    try await exchange(name, type: .fanout, durable: durable, autoDelete: autoDelete)
+  }
+
+  public func topic(_ name: String, durable: Bool = false, autoDelete: Bool = false) async throws
+    -> Exchange
+  {
+    try await exchange(name, type: .topic, durable: durable, autoDelete: autoDelete)
+  }
+
+  public func headers(_ name: String, durable: Bool = false, autoDelete: Bool = false) async throws
+    -> Exchange
+  {
+    try await exchange(name, type: .headers, durable: durable, autoDelete: autoDelete)
+  }
+
+  public var defaultExchange: Exchange {
+    Exchange(channel: self, name: "", type: .direct)
+  }
+
+  public func exchangeDelete(_ name: String, ifUnused: Bool = false) async throws {
+    let delete = ExchangeDelete(
+      reserved1: 0,
+      exchange: name,
+      ifUnused: ifUnused,
+      noWait: false
+    )
+    try await sendMethod(.exchangeDelete(delete))
+    let response = try await waitForResponse()
+    guard case .exchangeDeleteOk = response else {
+      throw ConnectionError.protocolError("Expected Exchange.DeleteOk, got \(response)")
+    }
+  }
+
+  public func exchangeBind(
+    destination: String,
+    source: String,
+    routingKey: String = "",
+    arguments: Table = [:]
+  ) async throws {
+    let bind = ExchangeBind(
+      reserved1: 0,
+      destination: destination,
+      source: source,
+      routingKey: routingKey,
+      noWait: false,
+      arguments: arguments
+    )
+    try await sendMethod(.exchangeBind(bind))
+    let response = try await waitForResponse()
+    guard case .exchangeBindOk = response else {
+      throw ConnectionError.protocolError("Expected Exchange.BindOk, got \(response)")
+    }
+  }
+
+  public func exchangeUnbind(
+    destination: String,
+    source: String,
+    routingKey: String = "",
+    arguments: Table = [:]
+  ) async throws {
+    let unbind = ExchangeUnbind(
+      reserved1: 0,
+      destination: destination,
+      source: source,
+      routingKey: routingKey,
+      noWait: false,
+      arguments: arguments
+    )
+    try await sendMethod(.exchangeUnbind(unbind))
+    let response = try await waitForResponse()
+    guard case .exchangeUnbindOk = response else {
+      throw ConnectionError.protocolError("Expected Exchange.UnbindOk, got \(response)")
+    }
+  }
+
+  // MARK: - Queue Operations
+
+  public func queue(
+    _ name: String = "",
+    type: QueueType? = nil,
+    durable: Bool = false,
+    exclusive: Bool = false,
+    autoDelete: Bool = false,
+    arguments: Table = [:]
+  ) async throws -> Queue {
+    var args = arguments
+    if let queueType = type {
+      args[XArguments.queueType] = queueType.asTableValue
+    }
+    let declare = QueueDeclare(
+      reserved1: 0,
+      queue: name,
+      passive: false,
+      durable: durable,
+      exclusive: exclusive,
+      autoDelete: autoDelete,
+      noWait: false,
+      arguments: args
+    )
+    try await sendMethod(.queueDeclare(declare))
+    let response = try await waitForResponse()
+    guard case .queueDeclareOk(let ok) = response else {
+      throw ConnectionError.protocolError("Expected Queue.DeclareOk, got \(response)")
+    }
+    return Queue(
+      channel: self, name: ok.queue, messageCount: ok.messageCount, consumerCount: ok.consumerCount)
+  }
+
+  public func queueDelete(
+    _ name: String,
+    ifUnused: Bool = false,
+    ifEmpty: Bool = false
+  ) async throws -> UInt32 {
+    let delete = QueueDelete(
+      reserved1: 0,
+      queue: name,
+      ifUnused: ifUnused,
+      ifEmpty: ifEmpty,
+      noWait: false
+    )
+    try await sendMethod(.queueDelete(delete))
+    let response = try await waitForResponse()
+    guard case .queueDeleteOk(let ok) = response else {
+      throw ConnectionError.protocolError("Expected Queue.DeleteOk, got \(response)")
+    }
+    return ok.messageCount
+  }
+
+  public func queuePurge(_ name: String) async throws -> UInt32 {
+    let purge = QueuePurge(reserved1: 0, queue: name, noWait: false)
+    try await sendMethod(.queuePurge(purge))
+    let response = try await waitForResponse()
+    guard case .queuePurgeOk(let ok) = response else {
+      throw ConnectionError.protocolError("Expected Queue.PurgeOk, got \(response)")
+    }
+    return ok.messageCount
+  }
+
+  public func queueBind(
+    queue: String,
+    exchange: String,
+    routingKey: String = "",
+    arguments: Table = [:]
+  ) async throws {
+    let bind = QueueBind(
+      reserved1: 0,
+      queue: queue,
+      exchange: exchange,
+      routingKey: routingKey,
+      noWait: false,
+      arguments: arguments
+    )
+    try await sendMethod(.queueBind(bind))
+    let response = try await waitForResponse()
+    guard case .queueBindOk = response else {
+      throw ConnectionError.protocolError("Expected Queue.BindOk, got \(response)")
+    }
+  }
+
+  public func queueUnbind(
+    queue: String,
+    exchange: String,
+    routingKey: String = "",
+    arguments: Table = [:]
+  ) async throws {
+    let unbind = QueueUnbind(
+      reserved1: 0,
+      queue: queue,
+      exchange: exchange,
+      routingKey: routingKey,
+      arguments: arguments
+    )
+    try await sendMethod(.queueUnbind(unbind))
+    let response = try await waitForResponse()
+    guard case .queueUnbindOk = response else {
+      throw ConnectionError.protocolError("Expected Queue.UnbindOk, got \(response)")
+    }
+  }
+
+  // MARK: - Publishing
+
+  /// Immediate flush for low-latency single messages.
+  ///
+  /// When publisher confirmation tracking is enabled, this method waits for broker
+  /// confirmation before returning. If the broker nacks the message, throws an error.
+  public func basicPublish(
+    body: Data,
+    exchange: String = "",
+    routingKey: String,
+    mandatory: Bool = false,
+    immediate: Bool = false,
+    properties: BasicProperties = .persistent
+  ) async throws {
+    guard isOpen, let connection = connection else {
+      throw ConnectionError.notConnected
     }
 
-    internal func open() async throws {
-        try await sendMethod(.channelOpen(ChannelOpen()))
-        let response = try await waitForResponse()
-        guard case .channelOpenOk = response else {
-            throw ConnectionError.protocolError("Expected Channel.OpenOk, got \(response)")
-        }
-        isOpen = true
+    // Wait for a slot if we're at the limit
+    if publisherConfirmationTracking {
+      await waitForConfirmSlot()
     }
 
-    // MARK: - Exchange Operations
+    let seqNo = confirmMode ? nextPublishSeqNo : 0
 
-    public func exchange(
-        _ name: String,
-        type: ExchangeType,
-        durable: Bool = false,
-        autoDelete: Bool = false,
-        internal: Bool = false,
-        arguments: Table = [:]
-    ) async throws -> Exchange {
-        let declare = ExchangeDeclare(
-            reserved1: 0,
-            exchange: name,
-            type: type.rawValue,
-            passive: false,
-            durable: durable,
-            autoDelete: autoDelete,
-            internal: `internal`,
-            noWait: false,
-            arguments: arguments
-        )
-        try await sendMethod(.exchangeDeclare(declare))
-        let response = try await waitForResponse()
-        guard case .exchangeDeclareOk = response else {
-            throw ConnectionError.protocolError("Expected Exchange.DeclareOk, got \(response)")
-        }
-        return Exchange(channel: self, name: name, type: type)
+    let frames = buildPublishFrames(
+      body: body,
+      exchange: exchange,
+      routingKey: routingKey,
+      mandatory: mandatory,
+      immediate: immediate,
+      properties: properties,
+      frameMax: await connection.frameMax
+    )
+
+    try await connection.writeBatch(frames)
+    await connection.flush()
+
+    if confirmMode {
+      nextPublishSeqNo += 1
+      if publisherConfirmationTracking {
+        try await awaitConfirmation(seqNo: seqNo)
+      }
+    }
+  }
+
+  /// Buffers writes for high throughput; call flush after batch.
+  ///
+  /// When publisher confirmation tracking is enabled, this method waits for broker
+  /// confirmation before returning. If the broker nacks the message, throws an error.
+  public func publish(
+    body: Data,
+    exchange: String = "",
+    routingKey: String,
+    mandatory: Bool = false,
+    properties: BasicProperties = .persistent
+  ) async throws {
+    guard isOpen, let connection = connection else {
+      throw ConnectionError.notConnected
     }
 
-    public func direct(_ name: String, durable: Bool = false, autoDelete: Bool = false) async throws -> Exchange {
-        try await exchange(name, type: .direct, durable: durable, autoDelete: autoDelete)
+    // Wait for a slot if we're at the limit
+    if publisherConfirmationTracking {
+      await waitForConfirmSlot()
     }
 
-    public func fanout(_ name: String, durable: Bool = false, autoDelete: Bool = false) async throws -> Exchange {
-        try await exchange(name, type: .fanout, durable: durable, autoDelete: autoDelete)
-    }
+    let seqNo = confirmMode ? nextPublishSeqNo : 0
 
-    public func topic(_ name: String, durable: Bool = false, autoDelete: Bool = false) async throws -> Exchange {
-        try await exchange(name, type: .topic, durable: durable, autoDelete: autoDelete)
-    }
+    let frames = buildPublishFrames(
+      body: body,
+      exchange: exchange,
+      routingKey: routingKey,
+      mandatory: mandatory,
+      immediate: false,
+      properties: properties,
+      frameMax: await connection.frameMax
+    )
 
-    public func headers(_ name: String, durable: Bool = false, autoDelete: Bool = false) async throws -> Exchange {
-        try await exchange(name, type: .headers, durable: durable, autoDelete: autoDelete)
-    }
+    try await connection.writeBatch(frames)
 
-    public var defaultExchange: Exchange {
-        Exchange(channel: self, name: "", type: .direct)
-    }
-
-    public func exchangeDelete(_ name: String, ifUnused: Bool = false) async throws {
-        let delete = ExchangeDelete(
-            reserved1: 0,
-            exchange: name,
-            ifUnused: ifUnused,
-            noWait: false
-        )
-        try await sendMethod(.exchangeDelete(delete))
-        let response = try await waitForResponse()
-        guard case .exchangeDeleteOk = response else {
-            throw ConnectionError.protocolError("Expected Exchange.DeleteOk, got \(response)")
-        }
-    }
-
-    public func exchangeBind(
-        destination: String,
-        source: String,
-        routingKey: String = "",
-        arguments: Table = [:]
-    ) async throws {
-        let bind = ExchangeBind(
-            reserved1: 0,
-            destination: destination,
-            source: source,
-            routingKey: routingKey,
-            noWait: false,
-            arguments: arguments
-        )
-        try await sendMethod(.exchangeBind(bind))
-        let response = try await waitForResponse()
-        guard case .exchangeBindOk = response else {
-            throw ConnectionError.protocolError("Expected Exchange.BindOk, got \(response)")
-        }
-    }
-
-    public func exchangeUnbind(
-        destination: String,
-        source: String,
-        routingKey: String = "",
-        arguments: Table = [:]
-    ) async throws {
-        let unbind = ExchangeUnbind(
-            reserved1: 0,
-            destination: destination,
-            source: source,
-            routingKey: routingKey,
-            noWait: false,
-            arguments: arguments
-        )
-        try await sendMethod(.exchangeUnbind(unbind))
-        let response = try await waitForResponse()
-        guard case .exchangeUnbindOk = response else {
-            throw ConnectionError.protocolError("Expected Exchange.UnbindOk, got \(response)")
-        }
-    }
-
-    // MARK: - Queue Operations
-
-    public func queue(
-        _ name: String = "",
-        type: QueueType? = nil,
-        durable: Bool = false,
-        exclusive: Bool = false,
-        autoDelete: Bool = false,
-        arguments: Table = [:]
-    ) async throws -> Queue {
-        var args = arguments
-        if let queueType = type {
-            args[XArguments.queueType] = queueType.asTableValue
-        }
-        let declare = QueueDeclare(
-            reserved1: 0,
-            queue: name,
-            passive: false,
-            durable: durable,
-            exclusive: exclusive,
-            autoDelete: autoDelete,
-            noWait: false,
-            arguments: args
-        )
-        try await sendMethod(.queueDeclare(declare))
-        let response = try await waitForResponse()
-        guard case .queueDeclareOk(let ok) = response else {
-            throw ConnectionError.protocolError("Expected Queue.DeclareOk, got \(response)")
-        }
-        return Queue(channel: self, name: ok.queue, messageCount: ok.messageCount, consumerCount: ok.consumerCount)
-    }
-
-    public func queueDelete(
-        _ name: String,
-        ifUnused: Bool = false,
-        ifEmpty: Bool = false
-    ) async throws -> UInt32 {
-        let delete = QueueDelete(
-            reserved1: 0,
-            queue: name,
-            ifUnused: ifUnused,
-            ifEmpty: ifEmpty,
-            noWait: false
-        )
-        try await sendMethod(.queueDelete(delete))
-        let response = try await waitForResponse()
-        guard case .queueDeleteOk(let ok) = response else {
-            throw ConnectionError.protocolError("Expected Queue.DeleteOk, got \(response)")
-        }
-        return ok.messageCount
-    }
-
-    public func queuePurge(_ name: String) async throws -> UInt32 {
-        let purge = QueuePurge(reserved1: 0, queue: name, noWait: false)
-        try await sendMethod(.queuePurge(purge))
-        let response = try await waitForResponse()
-        guard case .queuePurgeOk(let ok) = response else {
-            throw ConnectionError.protocolError("Expected Queue.PurgeOk, got \(response)")
-        }
-        return ok.messageCount
-    }
-
-    public func queueBind(
-        queue: String,
-        exchange: String,
-        routingKey: String = "",
-        arguments: Table = [:]
-    ) async throws {
-        let bind = QueueBind(
-            reserved1: 0,
-            queue: queue,
-            exchange: exchange,
-            routingKey: routingKey,
-            noWait: false,
-            arguments: arguments
-        )
-        try await sendMethod(.queueBind(bind))
-        let response = try await waitForResponse()
-        guard case .queueBindOk = response else {
-            throw ConnectionError.protocolError("Expected Queue.BindOk, got \(response)")
-        }
-    }
-
-    public func queueUnbind(
-        queue: String,
-        exchange: String,
-        routingKey: String = "",
-        arguments: Table = [:]
-    ) async throws {
-        let unbind = QueueUnbind(
-            reserved1: 0,
-            queue: queue,
-            exchange: exchange,
-            routingKey: routingKey,
-            arguments: arguments
-        )
-        try await sendMethod(.queueUnbind(unbind))
-        let response = try await waitForResponse()
-        guard case .queueUnbindOk = response else {
-            throw ConnectionError.protocolError("Expected Queue.UnbindOk, got \(response)")
-        }
-    }
-
-    // MARK: - Publishing
-
-    /// Immediate flush for low-latency single messages.
-    ///
-    /// When publisher confirmation tracking is enabled, this method waits for broker
-    /// confirmation before returning. If the broker nacks the message, throws an error.
-    public func basicPublish(
-        body: Data,
-        exchange: String = "",
-        routingKey: String,
-        mandatory: Bool = false,
-        immediate: Bool = false,
-        properties: BasicProperties = .persistent
-    ) async throws {
-        guard isOpen, let connection = connection else {
-            throw ConnectionError.notConnected
-        }
-
-        // Wait for a slot if we're at the limit
-        if publisherConfirmationTracking {
-            await waitForConfirmSlot()
-        }
-
-        let seqNo = confirmMode ? nextPublishSeqNo : 0
-
-        let frames = buildPublishFrames(
-            body: body,
-            exchange: exchange,
-            routingKey: routingKey,
-            mandatory: mandatory,
-            immediate: immediate,
-            properties: properties,
-            frameMax: await connection.frameMax
-        )
-
-        try await connection.writeBatch(frames)
+    if confirmMode {
+      nextPublishSeqNo += 1
+      if publisherConfirmationTracking {
         await connection.flush()
+        try await awaitConfirmation(seqNo: seqNo)
+      }
+    }
+  }
 
-        if confirmMode {
-            nextPublishSeqNo += 1
-            if publisherConfirmationTracking {
-                try await awaitConfirmation(seqNo: seqNo)
-            }
-        }
+  private func waitForConfirmSlot() async {
+    guard outstandingConfirmsLimit > 0 else { return }
+    while outstandingConfirmsCount >= outstandingConfirmsLimit {
+      await withCheckedContinuation { cont in
+        confirmLimitWaiters.append(cont)
+      }
+    }
+    outstandingConfirmsCount += 1
+  }
+
+  private func awaitConfirmation(seqNo: UInt64) async throws {
+    let confirmed = try await withCheckedThrowingContinuation { cont in
+      confirmHandlers[seqNo] = cont
+    }
+    if !confirmed {
+      throw ConnectionError.publisherNack(seqNo: seqNo)
+    }
+  }
+
+  public func flush() async {
+    await connection?.flush()
+  }
+
+  private func buildPublishFrames(
+    body: Data,
+    exchange: String,
+    routingKey: String,
+    mandatory: Bool,
+    immediate: Bool,
+    properties: BasicProperties,
+    frameMax: UInt32
+  ) -> [Frame] {
+    let maxBodySize = Int(frameMax) - 8
+    let bodyFrameCount = body.isEmpty ? 1 : (body.count + maxBodySize - 1) / maxBodySize
+    var frames: [Frame] = []
+    frames.reserveCapacity(2 + bodyFrameCount)
+
+    let publish = BasicPublish(
+      reserved1: 0,
+      exchange: exchange,
+      routingKey: routingKey,
+      mandatory: mandatory,
+      immediate: immediate
+    )
+    frames.append(.method(channelID: channelID, method: .basicPublish(publish)))
+
+    frames.append(
+      .header(
+        channelID: channelID,
+        classID: ClassID.basic.rawValue,
+        bodySize: UInt64(body.count),
+        properties: properties
+      ))
+
+    if body.count <= maxBodySize {
+      // Fast path: body fits in single frame, no copy needed
+      frames.append(.body(channelID: channelID, payload: body))
+    } else {
+      // Chunked: split into multiple frames
+      var offset = 0
+      while offset < body.count {
+        let end = min(offset + maxBodySize, body.count)
+        frames.append(.body(channelID: channelID, payload: body[offset..<end]))
+        offset = end
+      }
     }
 
-    /// Buffers writes for high throughput; call flush after batch.
-    ///
-    /// When publisher confirmation tracking is enabled, this method waits for broker
-    /// confirmation before returning. If the broker nacks the message, throws an error.
-    public func publish(
-        body: Data,
-        exchange: String = "",
-        routingKey: String,
-        mandatory: Bool = false,
-        properties: BasicProperties = .persistent
-    ) async throws {
-        guard isOpen, let connection = connection else {
-            throw ConnectionError.notConnected
-        }
+    return frames
+  }
 
-        // Wait for a slot if we're at the limit
-        if publisherConfirmationTracking {
-            await waitForConfirmSlot()
-        }
+  // MARK: - Consuming
 
-        let seqNo = confirmMode ? nextPublishSeqNo : 0
-
-        let frames = buildPublishFrames(
-            body: body,
-            exchange: exchange,
-            routingKey: routingKey,
-            mandatory: mandatory,
-            immediate: false,
-            properties: properties,
-            frameMax: await connection.frameMax
-        )
-
-        try await connection.writeBatch(frames)
-
-        if confirmMode {
-            nextPublishSeqNo += 1
-            if publisherConfirmationTracking {
-                await connection.flush()
-                try await awaitConfirmation(seqNo: seqNo)
-            }
-        }
+  public func basicConsume(
+    queue: String,
+    consumerTag: String = "",
+    acknowledgementMode: ConsumerAcknowledgementMode = .manual,
+    exclusive: Bool = false,
+    arguments: Table = [:]
+  ) async throws -> MessageStream {
+    let consume = BasicConsume(
+      reserved1: 0,
+      queue: queue,
+      consumerTag: consumerTag,
+      noLocal: false,
+      noAck: acknowledgementMode.noAckFieldValue,
+      exclusive: exclusive,
+      noWait: false,
+      arguments: arguments
+    )
+    try await sendMethod(.basicConsume(consume))
+    let response = try await waitForResponse()
+    guard case .basicConsumeOk(let ok) = response else {
+      throw ConnectionError.protocolError("Expected Basic.ConsumeOk, got \(response)")
     }
 
-    private func waitForConfirmSlot() async {
-        guard outstandingConfirmsLimit > 0 else { return }
-        while outstandingConfirmsCount >= outstandingConfirmsLimit {
-            await withCheckedContinuation { cont in
-                confirmLimitWaiters.append(cont)
-            }
-        }
-        outstandingConfirmsCount += 1
+    let (stream, continuation) = AsyncStream<Message>.makeStream()
+    consumers[ok.consumerTag] = continuation
+    return MessageStream(channel: self, consumerTag: ok.consumerTag, stream: stream)
+  }
+
+  public func basicCancel(_ consumerTag: String) async throws {
+    let cancel = BasicCancel(consumerTag: consumerTag, noWait: false)
+    try await sendMethod(.basicCancel(cancel))
+    let response = try await waitForResponse()
+    guard case .basicCancelOk = response else {
+      throw ConnectionError.protocolError("Expected Basic.CancelOk, got \(response)")
     }
+    removeConsumer(consumerTag)
+  }
 
-    private func awaitConfirmation(seqNo: UInt64) async throws {
-        let confirmed = try await withCheckedThrowingContinuation { cont in
-            confirmHandlers[seqNo] = cont
-        }
-        if !confirmed {
-            throw ConnectionError.publisherNack(seqNo: seqNo)
-        }
+  /// Synchronously fetch a single message from a queue (pull API).
+  ///
+  /// - Warning: This method is inefficient and strongly discouraged for production use.
+  ///   It requires a network round-trip per message, resulting in very low throughput.
+  ///   Use ``basicConsume(queue:consumerTag:acknowledgementMode:exclusive:arguments:)`` instead for
+  ///   efficient push-based message delivery.
+  ///
+  /// This method is suitable only for tests, debugging, or administrative tools
+  /// where occasional single-message retrieval is acceptable.
+  ///
+  /// - Parameters:
+  ///   - queue: The queue name to fetch from
+  ///   - acknowledgementMode: Whether messages require manual acknowledgement (default) or are auto-acknowledged.
+  /// - Returns: A ``GetResponse`` if a message was available, or `nil` if the queue was empty.
+  @_documentation(visibility: private)
+  public func basicGet(queue: String, acknowledgementMode: ConsumerAcknowledgementMode = .manual)
+    async throws -> GetResponse?
+  {
+    let get = BasicGet(reserved1: 0, queue: queue, noAck: acknowledgementMode.noAckFieldValue)
+    try await sendMethod(.basicGet(get))
+
+    return try await withCheckedThrowingContinuation { cont in
+      pendingGetResponses.append(cont)
     }
+  }
 
-    public func flush() async {
-        await connection?.flush()
+  // MARK: - Acknowledgements
+
+  public func basicAck(deliveryTag: UInt64, multiple: Bool = false) async throws {
+    let ack = BasicAck(deliveryTag: deliveryTag, multiple: multiple)
+    try await sendMethod(.basicAck(ack))
+  }
+
+  public func basicNack(deliveryTag: UInt64, multiple: Bool = false, requeue: Bool = true)
+    async throws
+  {
+    let nack = BasicNack(deliveryTag: deliveryTag, multiple: multiple, requeue: requeue)
+    try await sendMethod(.basicNack(nack))
+  }
+
+  public func basicReject(deliveryTag: UInt64, requeue: Bool = true) async throws {
+    let reject = BasicReject(deliveryTag: deliveryTag, requeue: requeue)
+    try await sendMethod(.basicReject(reject))
+  }
+
+  // MARK: - QoS
+
+  public func basicQos(prefetchSize: UInt32 = 0, prefetchCount: UInt16 = 0, global: Bool = false)
+    async throws
+  {
+    let qos = BasicQos(prefetchSize: prefetchSize, prefetchCount: prefetchCount, global: global)
+    try await sendMethod(.basicQos(qos))
+    let response = try await waitForResponse()
+    guard case .basicQosOk = response else {
+      throw ConnectionError.protocolError("Expected Basic.QosOk, got \(response)")
     }
+  }
 
-    private func buildPublishFrames(
-        body: Data,
-        exchange: String,
-        routingKey: String,
-        mandatory: Bool,
-        immediate: Bool,
-        properties: BasicProperties,
-        frameMax: UInt32
-    ) -> [Frame] {
-        let maxBodySize = Int(frameMax) - 8
-        let bodyFrameCount = body.isEmpty ? 1 : (body.count + maxBodySize - 1) / maxBodySize
-        var frames: [Frame] = []
-        frames.reserveCapacity(2 + bodyFrameCount)
+  // MARK: - Publisher Confirms
 
-        let publish = BasicPublish(
-            reserved1: 0,
-            exchange: exchange,
-            routingKey: routingKey,
-            mandatory: mandatory,
-            immediate: immediate
-        )
-        frames.append(.method(channelID: channelID, method: .basicPublish(publish)))
+  /// Enable publisher confirms mode.
+  ///
+  /// - Parameter tracking: If `true`, publish methods will automatically wait for broker
+  ///   confirmation before returning. Defaults to `false`.
+  /// - Parameter outstandingLimit: Maximum number of unconfirmed messages before publish
+  ///   methods block. Only applies when `tracking` is `true`. Use `0` for unlimited.
+  public func confirmSelect(tracking: Bool = false, outstandingLimit: Int = 0) async throws {
+    let select = ConfirmSelect(noWait: false)
+    try await sendMethod(.confirmSelect(select))
+    let response = try await waitForResponse()
+    guard case .confirmSelectOk = response else {
+      throw ConnectionError.protocolError("Expected Confirm.SelectOk, got \(response)")
+    }
+    confirmMode = true
+    publisherConfirmationTracking = tracking
+    outstandingConfirmsLimit = outstandingLimit
+    nextPublishSeqNo = 1
+  }
 
-        frames.append(.header(
-            channelID: channelID,
-            classID: ClassID.basic.rawValue,
-            bodySize: UInt64(body.count),
-            properties: properties
-        ))
+  /// Whether publisher confirmation tracking is enabled.
+  public var isPublisherConfirmationTrackingEnabled: Bool {
+    publisherConfirmationTracking
+  }
 
-        if body.count <= maxBodySize {
-            // Fast path: body fits in single frame, no copy needed
-            frames.append(.body(channelID: channelID, payload: body))
+  public var publishSeqNo: UInt64 {
+    nextPublishSeqNo
+  }
+
+  /// Wait for all outstanding publisher confirmations to complete.
+  public func waitForConfirms() async throws {
+    guard confirmMode else { return }
+    while !confirmHandlers.isEmpty {
+      try await Task.sleep(nanoseconds: 10_000_000)  // 10ms
+    }
+  }
+
+  // MARK: - Transactions
+
+  public func txSelect() async throws {
+    try await sendMethod(.txSelect)
+    let response = try await waitForResponse()
+    guard case .txSelectOk = response else {
+      throw ConnectionError.protocolError("Expected Tx.SelectOk, got \(response)")
+    }
+    transactionMode = true
+  }
+
+  public func txCommit() async throws {
+    try await sendMethod(.txCommit)
+    let response = try await waitForResponse()
+    guard case .txCommitOk = response else {
+      throw ConnectionError.protocolError("Expected Tx.CommitOk, got \(response)")
+    }
+  }
+
+  public func txRollback() async throws {
+    try await sendMethod(.txRollback)
+    let response = try await waitForResponse()
+    guard case .txRollbackOk = response else {
+      throw ConnectionError.protocolError("Expected Tx.RollbackOk, got \(response)")
+    }
+  }
+
+  // MARK: - Returns
+
+  public func onReturn(_ handler: @escaping @Sendable (ReturnedMessage) -> Void) {
+    returnHandlers.append(handler)
+  }
+
+  // MARK: - Channel Close Events
+
+  /// Register a handler for channel close events (server or client initiated)
+  public func onClose(_ handler: @escaping @Sendable (ChannelCloseInfo) -> Void) {
+    closeHandlers.append(handler)
+  }
+
+  // MARK: - Frame Handling
+
+  internal func handleFrame(_ frame: Frame) async {
+    switch frame {
+    case .method(channelID: _, let method):
+      await handleMethod(method)
+    case .header(channelID: _, classID: _, let bodySize, let properties):
+      if var msg = incomingMessage {
+        msg.properties = properties
+        msg.bodySize = bodySize
+        incomingMessage = msg
+      }
+    case .body(channelID: _, payload: let chunk):
+      if var msg = incomingMessage {
+        msg.appendBody(chunk)
+        if UInt64(msg.receivedBytes) >= msg.bodySize {
+          await deliverMessage(msg)
+          incomingMessage = nil
         } else {
-            // Chunked: split into multiple frames
-            var offset = 0
-            while offset < body.count {
-                let end = min(offset + maxBodySize, body.count)
-                frames.append(.body(channelID: channelID, payload: body[offset..<end]))
-                offset = end
-            }
+          incomingMessage = msg
         }
-
-        return frames
+      }
+    case .heartbeat:
+      break
     }
+  }
 
-    // MARK: - Consuming
+  private func handleMethod(_ method: AMQPMethod) async {
+    switch method {
+    case .channelOpenOk, .channelCloseOk, .channelFlowOk,
+      .exchangeDeclareOk, .exchangeDeleteOk, .exchangeBindOk, .exchangeUnbindOk,
+      .queueDeclareOk, .queueDeleteOk, .queuePurgeOk, .queueBindOk, .queueUnbindOk,
+      .basicQosOk, .basicConsumeOk, .basicCancelOk, .basicRecoverOk,
+      .txSelectOk, .txCommitOk, .txRollbackOk,
+      .confirmSelectOk:
+      if let cont = pendingResponses.first {
+        pendingResponses.removeFirst()
+        cont.resume(returning: method)
+      }
 
-    public func basicConsume(
-        queue: String,
-        consumerTag: String = "",
-        acknowledgementMode: ConsumerAcknowledgementMode = .manual,
-        exclusive: Bool = false,
-        arguments: Table = [:]
-    ) async throws -> MessageStream {
-        let consume = BasicConsume(
-            reserved1: 0,
-            queue: queue,
-            consumerTag: consumerTag,
-            noLocal: false,
-            noAck: acknowledgementMode.noAckFieldValue,
-            exclusive: exclusive,
-            noWait: false,
-            arguments: arguments
+    case .channelClose(let close):
+      isOpen = false
+      try? await sendMethod(.channelCloseOk)
+      let error = ConnectionError.channelClosed(
+        replyCode: close.replyCode,
+        replyText: close.replyText,
+        classID: close.classId,
+        methodID: close.methodId
+      )
+      // Notify close handlers
+      let closeInfo = ChannelCloseInfo(
+        replyCode: close.replyCode,
+        replyText: close.replyText,
+        classID: close.classId,
+        methodID: close.methodId,
+        initiatedByServer: true
+      )
+      for handler in closeHandlers {
+        handler(closeInfo)
+      }
+      for cont in pendingResponses {
+        cont.resume(throwing: error)
+      }
+      pendingResponses.removeAll()
+      for cont in pendingGetResponses {
+        cont.resume(throwing: error)
+      }
+      pendingGetResponses.removeAll()
+      await connection?.channelClosed(channelID)
+
+    case .basicDeliver(let deliver):
+      incomingMessage = IncomingMessage(
+        properties: BasicProperties(),
+        bodySize: 0,
+        deliveryInfo: DeliveryInfo(
+          consumerTag: deliver.consumerTag,
+          deliveryTag: deliver.deliveryTag,
+          redelivered: deliver.redelivered,
+          exchange: deliver.exchange,
+          routingKey: deliver.routingKey
         )
-        try await sendMethod(.basicConsume(consume))
-        let response = try await waitForResponse()
-        guard case .basicConsumeOk(let ok) = response else {
-            throw ConnectionError.protocolError("Expected Basic.ConsumeOk, got \(response)")
-        }
+      )
 
-        let (stream, continuation) = AsyncStream<Message>.makeStream()
-        consumers[ok.consumerTag] = continuation
-        return MessageStream(channel: self, consumerTag: ok.consumerTag, stream: stream)
+    case .basicGetOk(let ok):
+      incomingMessage = IncomingMessage(
+        properties: BasicProperties(),
+        bodySize: 0,
+        getInfo: GetInfo(
+          deliveryTag: ok.deliveryTag,
+          redelivered: ok.redelivered,
+          exchange: ok.exchange,
+          routingKey: ok.routingKey,
+          messageCount: ok.messageCount
+        )
+      )
+
+    case .basicGetEmpty:
+      if let cont = pendingGetResponses.first {
+        pendingGetResponses.removeFirst()
+        cont.resume(returning: nil)
+      }
+
+    case .basicReturn(let ret):
+      incomingMessage = IncomingMessage(
+        properties: BasicProperties(),
+        bodySize: 0,
+        returnInfo: ReturnInfo(
+          replyCode: ret.replyCode,
+          replyText: ret.replyText,
+          exchange: ret.exchange,
+          routingKey: ret.routingKey
+        )
+      )
+
+    case .basicAck(let ack):
+      handleConfirm(deliveryTag: ack.deliveryTag, multiple: ack.multiple, ack: true)
+
+    case .basicNack(let nack):
+      handleConfirm(deliveryTag: nack.deliveryTag, multiple: nack.multiple, ack: false)
+
+    case .basicCancel(let cancel):
+      removeConsumer(cancel.consumerTag)
+      let cancelOk = BasicCancelOk(consumerTag: cancel.consumerTag)
+      try? await sendMethod(.basicCancelOk(cancelOk))
+
+    default:
+      break
+    }
+  }
+
+  private func deliverMessage(_ incoming: IncomingMessage) async {
+    let body = incoming.assembleBody()
+    if let deliveryInfo = incoming.deliveryInfo {
+      let message = Message(
+        body: body,
+        properties: incoming.properties,
+        deliveryInfo: deliveryInfo,
+        channel: self
+      )
+      consumers[deliveryInfo.consumerTag]?.yield(message)
+    } else if let getInfo = incoming.getInfo {
+      let response = GetResponse(
+        body: body,
+        properties: incoming.properties,
+        deliveryTag: getInfo.deliveryTag,
+        redelivered: getInfo.redelivered,
+        exchange: getInfo.exchange,
+        routingKey: getInfo.routingKey,
+        messageCount: getInfo.messageCount,
+        channel: self
+      )
+      if let cont = pendingGetResponses.first {
+        pendingGetResponses.removeFirst()
+        cont.resume(returning: response)
+      }
+    } else if let returnInfo = incoming.returnInfo {
+      let returned = ReturnedMessage(
+        body: body,
+        properties: incoming.properties,
+        replyCode: returnInfo.replyCode,
+        replyText: returnInfo.replyText,
+        exchange: returnInfo.exchange,
+        routingKey: returnInfo.routingKey
+      )
+      for handler in returnHandlers {
+        handler(returned)
+      }
+    }
+  }
+
+  private func handleConfirm(deliveryTag: UInt64, multiple: Bool, ack: Bool) {
+    var confirmedCount = 0
+    if multiple {
+      var toResume: [(UInt64, CheckedContinuation<Bool, Error>)] = []
+      for (tag, cont) in confirmHandlers where tag <= deliveryTag {
+        toResume.append((tag, cont))
+      }
+      for (tag, cont) in toResume {
+        confirmHandlers.removeValue(forKey: tag)
+        cont.resume(returning: ack)
+        confirmedCount += 1
+      }
+    } else if let cont = confirmHandlers.removeValue(forKey: deliveryTag) {
+      cont.resume(returning: ack)
+      confirmedCount += 1
     }
 
-    public func basicCancel(_ consumerTag: String) async throws {
-        let cancel = BasicCancel(consumerTag: consumerTag, noWait: false)
-        try await sendMethod(.basicCancel(cancel))
-        let response = try await waitForResponse()
-        guard case .basicCancelOk = response else {
-            throw ConnectionError.protocolError("Expected Basic.CancelOk, got \(response)")
-        }
-        removeConsumer(consumerTag)
+    // Release waiters if we freed up slots
+    if publisherConfirmationTracking && outstandingConfirmsLimit > 0 {
+      outstandingConfirmsCount -= confirmedCount
+      while !confirmLimitWaiters.isEmpty && outstandingConfirmsCount < outstandingConfirmsLimit {
+        let waiter = confirmLimitWaiters.removeFirst()
+        waiter.resume()
+      }
     }
+  }
 
-    /// Synchronously fetch a single message from a queue (pull API).
-    ///
-    /// - Warning: This method is inefficient and strongly discouraged for production use.
-    ///   It requires a network round-trip per message, resulting in very low throughput.
-    ///   Use ``basicConsume(queue:consumerTag:acknowledgementMode:exclusive:arguments:)`` instead for
-    ///   efficient push-based message delivery.
-    ///
-    /// This method is suitable only for tests, debugging, or administrative tools
-    /// where occasional single-message retrieval is acceptable.
-    ///
-    /// - Parameters:
-    ///   - queue: The queue name to fetch from
-    ///   - acknowledgementMode: Whether messages require manual acknowledgement (default) or are auto-acknowledged.
-    /// - Returns: A ``GetResponse`` if a message was available, or `nil` if the queue was empty.
-    @_documentation(visibility: private)
-    public func basicGet(queue: String, acknowledgementMode: ConsumerAcknowledgementMode = .manual) async throws -> GetResponse? {
-        let get = BasicGet(reserved1: 0, queue: queue, noAck: acknowledgementMode.noAckFieldValue)
-        try await sendMethod(.basicGet(get))
+  // MARK: - Private Helpers
 
-        return try await withCheckedThrowingContinuation { cont in
-            pendingGetResponses.append(cont)
-        }
+  private func removeConsumer(_ tag: String) {
+    consumers[tag]?.finish()
+    consumers.removeValue(forKey: tag)
+  }
+
+  private func sendMethod(_ method: AMQPMethod) async throws {
+    guard let connection = connection else {
+      throw ConnectionError.notConnected
     }
+    try await connection.send(.method(channelID: channelID, method: method))
+  }
 
-    // MARK: - Acknowledgements
-
-    public func basicAck(deliveryTag: UInt64, multiple: Bool = false) async throws {
-        let ack = BasicAck(deliveryTag: deliveryTag, multiple: multiple)
-        try await sendMethod(.basicAck(ack))
+  private func waitForResponse() async throws -> AMQPMethod {
+    try await withCheckedThrowingContinuation { cont in
+      pendingResponses.append(cont)
     }
+  }
 
-    public func basicNack(deliveryTag: UInt64, multiple: Bool = false, requeue: Bool = true) async throws {
-        let nack = BasicNack(deliveryTag: deliveryTag, multiple: multiple, requeue: requeue)
-        try await sendMethod(.basicNack(nack))
+  // MARK: - Close
+
+  public func close() async throws {
+    guard isOpen else { return }
+    isOpen = false
+
+    for continuation in consumers.values {
+      continuation.finish()
     }
+    consumers.removeAll()
 
-    public func basicReject(deliveryTag: UInt64, requeue: Bool = true) async throws {
-        let reject = BasicReject(deliveryTag: deliveryTag, requeue: requeue)
-        try await sendMethod(.basicReject(reject))
-    }
+    let close = ChannelClose(replyCode: 200, replyText: "Normal shutdown", classId: 0, methodId: 0)
+    try await sendMethod(.channelClose(close))
+    _ = try? await waitForResponse()
 
-    // MARK: - QoS
+    await connection?.channelClosed(channelID)
+  }
 
-    public func basicQos(prefetchSize: UInt32 = 0, prefetchCount: UInt16 = 0, global: Bool = false) async throws {
-        let qos = BasicQos(prefetchSize: prefetchSize, prefetchCount: prefetchCount, global: global)
-        try await sendMethod(.basicQos(qos))
-        let response = try await waitForResponse()
-        guard case .basicQosOk = response else {
-            throw ConnectionError.protocolError("Expected Basic.QosOk, got \(response)")
-        }
-    }
+  // MARK: - Properties
 
-    // MARK: - Publisher Confirms
-
-    /// Enable publisher confirms mode.
-    ///
-    /// - Parameter tracking: If `true`, publish methods will automatically wait for broker
-    ///   confirmation before returning. Defaults to `false`.
-    /// - Parameter outstandingLimit: Maximum number of unconfirmed messages before publish
-    ///   methods block. Only applies when `tracking` is `true`. Use `0` for unlimited.
-    public func confirmSelect(tracking: Bool = false, outstandingLimit: Int = 0) async throws {
-        let select = ConfirmSelect(noWait: false)
-        try await sendMethod(.confirmSelect(select))
-        let response = try await waitForResponse()
-        guard case .confirmSelectOk = response else {
-            throw ConnectionError.protocolError("Expected Confirm.SelectOk, got \(response)")
-        }
-        confirmMode = true
-        publisherConfirmationTracking = tracking
-        outstandingConfirmsLimit = outstandingLimit
-        nextPublishSeqNo = 1
-    }
-
-    /// Whether publisher confirmation tracking is enabled.
-    public var isPublisherConfirmationTrackingEnabled: Bool {
-        publisherConfirmationTracking
-    }
-
-    public var publishSeqNo: UInt64 {
-        nextPublishSeqNo
-    }
-
-    /// Wait for all outstanding publisher confirmations to complete.
-    public func waitForConfirms() async throws {
-        guard confirmMode else { return }
-        while !confirmHandlers.isEmpty {
-            try await Task.sleep(nanoseconds: 10_000_000) // 10ms
-        }
-    }
-
-    // MARK: - Transactions
-
-    public func txSelect() async throws {
-        try await sendMethod(.txSelect)
-        let response = try await waitForResponse()
-        guard case .txSelectOk = response else {
-            throw ConnectionError.protocolError("Expected Tx.SelectOk, got \(response)")
-        }
-        transactionMode = true
-    }
-
-    public func txCommit() async throws {
-        try await sendMethod(.txCommit)
-        let response = try await waitForResponse()
-        guard case .txCommitOk = response else {
-            throw ConnectionError.protocolError("Expected Tx.CommitOk, got \(response)")
-        }
-    }
-
-    public func txRollback() async throws {
-        try await sendMethod(.txRollback)
-        let response = try await waitForResponse()
-        guard case .txRollbackOk = response else {
-            throw ConnectionError.protocolError("Expected Tx.RollbackOk, got \(response)")
-        }
-    }
-
-    // MARK: - Returns
-
-    public func onReturn(_ handler: @escaping @Sendable (ReturnedMessage) -> Void) {
-        returnHandlers.append(handler)
-    }
-
-    // MARK: - Channel Close Events
-
-    /// Register a handler for channel close events (server or client initiated)
-    public func onClose(_ handler: @escaping @Sendable (ChannelCloseInfo) -> Void) {
-        closeHandlers.append(handler)
-    }
-
-    // MARK: - Frame Handling
-
-    internal func handleFrame(_ frame: Frame) async {
-        switch frame {
-        case .method(channelID: _, method: let method):
-            await handleMethod(method)
-        case .header(channelID: _, classID: _, bodySize: let bodySize, properties: let properties):
-            if var msg = incomingMessage {
-                msg.properties = properties
-                msg.bodySize = bodySize
-                incomingMessage = msg
-            }
-        case .body(channelID: _, payload: let chunk):
-            if var msg = incomingMessage {
-                msg.appendBody(chunk)
-                if UInt64(msg.receivedBytes) >= msg.bodySize {
-                    await deliverMessage(msg)
-                    incomingMessage = nil
-                } else {
-                    incomingMessage = msg
-                }
-            }
-        case .heartbeat:
-            break
-        }
-    }
-
-    private func handleMethod(_ method: AMQPMethod) async {
-        switch method {
-        case .channelOpenOk, .channelCloseOk, .channelFlowOk,
-             .exchangeDeclareOk, .exchangeDeleteOk, .exchangeBindOk, .exchangeUnbindOk,
-             .queueDeclareOk, .queueDeleteOk, .queuePurgeOk, .queueBindOk, .queueUnbindOk,
-             .basicQosOk, .basicConsumeOk, .basicCancelOk, .basicRecoverOk,
-             .txSelectOk, .txCommitOk, .txRollbackOk,
-             .confirmSelectOk:
-            if let cont = pendingResponses.first {
-                pendingResponses.removeFirst()
-                cont.resume(returning: method)
-            }
-
-        case .channelClose(let close):
-            isOpen = false
-            try? await sendMethod(.channelCloseOk)
-            let error = ConnectionError.channelClosed(
-                replyCode: close.replyCode,
-                replyText: close.replyText,
-                classID: close.classId,
-                methodID: close.methodId
-            )
-            // Notify close handlers
-            let closeInfo = ChannelCloseInfo(
-                replyCode: close.replyCode,
-                replyText: close.replyText,
-                classID: close.classId,
-                methodID: close.methodId,
-                initiatedByServer: true
-            )
-            for handler in closeHandlers {
-                handler(closeInfo)
-            }
-            for cont in pendingResponses {
-                cont.resume(throwing: error)
-            }
-            pendingResponses.removeAll()
-            for cont in pendingGetResponses {
-                cont.resume(throwing: error)
-            }
-            pendingGetResponses.removeAll()
-            await connection?.channelClosed(channelID)
-
-        case .basicDeliver(let deliver):
-            incomingMessage = IncomingMessage(
-                properties: BasicProperties(),
-                bodySize: 0,
-                deliveryInfo: DeliveryInfo(
-                    consumerTag: deliver.consumerTag,
-                    deliveryTag: deliver.deliveryTag,
-                    redelivered: deliver.redelivered,
-                    exchange: deliver.exchange,
-                    routingKey: deliver.routingKey
-                )
-            )
-
-        case .basicGetOk(let ok):
-            incomingMessage = IncomingMessage(
-                properties: BasicProperties(),
-                bodySize: 0,
-                getInfo: GetInfo(
-                    deliveryTag: ok.deliveryTag,
-                    redelivered: ok.redelivered,
-                    exchange: ok.exchange,
-                    routingKey: ok.routingKey,
-                    messageCount: ok.messageCount
-                )
-            )
-
-        case .basicGetEmpty:
-            if let cont = pendingGetResponses.first {
-                pendingGetResponses.removeFirst()
-                cont.resume(returning: nil)
-            }
-
-        case .basicReturn(let ret):
-            incomingMessage = IncomingMessage(
-                properties: BasicProperties(),
-                bodySize: 0,
-                returnInfo: ReturnInfo(
-                    replyCode: ret.replyCode,
-                    replyText: ret.replyText,
-                    exchange: ret.exchange,
-                    routingKey: ret.routingKey
-                )
-            )
-
-        case .basicAck(let ack):
-            handleConfirm(deliveryTag: ack.deliveryTag, multiple: ack.multiple, ack: true)
-
-        case .basicNack(let nack):
-            handleConfirm(deliveryTag: nack.deliveryTag, multiple: nack.multiple, ack: false)
-
-        case .basicCancel(let cancel):
-            removeConsumer(cancel.consumerTag)
-            let cancelOk = BasicCancelOk(consumerTag: cancel.consumerTag)
-            try? await sendMethod(.basicCancelOk(cancelOk))
-
-        default:
-            break
-        }
-    }
-
-    private func deliverMessage(_ incoming: IncomingMessage) async {
-        let body = incoming.assembleBody()
-        if let deliveryInfo = incoming.deliveryInfo {
-            let message = Message(
-                body: body,
-                properties: incoming.properties,
-                deliveryInfo: deliveryInfo,
-                channel: self
-            )
-            consumers[deliveryInfo.consumerTag]?.yield(message)
-        } else if let getInfo = incoming.getInfo {
-            let response = GetResponse(
-                body: body,
-                properties: incoming.properties,
-                deliveryTag: getInfo.deliveryTag,
-                redelivered: getInfo.redelivered,
-                exchange: getInfo.exchange,
-                routingKey: getInfo.routingKey,
-                messageCount: getInfo.messageCount,
-                channel: self
-            )
-            if let cont = pendingGetResponses.first {
-                pendingGetResponses.removeFirst()
-                cont.resume(returning: response)
-            }
-        } else if let returnInfo = incoming.returnInfo {
-            let returned = ReturnedMessage(
-                body: body,
-                properties: incoming.properties,
-                replyCode: returnInfo.replyCode,
-                replyText: returnInfo.replyText,
-                exchange: returnInfo.exchange,
-                routingKey: returnInfo.routingKey
-            )
-            for handler in returnHandlers {
-                handler(returned)
-            }
-        }
-    }
-
-    private func handleConfirm(deliveryTag: UInt64, multiple: Bool, ack: Bool) {
-        var confirmedCount = 0
-        if multiple {
-            var toResume: [(UInt64, CheckedContinuation<Bool, Error>)] = []
-            for (tag, cont) in confirmHandlers where tag <= deliveryTag {
-                toResume.append((tag, cont))
-            }
-            for (tag, cont) in toResume {
-                confirmHandlers.removeValue(forKey: tag)
-                cont.resume(returning: ack)
-                confirmedCount += 1
-            }
-        } else if let cont = confirmHandlers.removeValue(forKey: deliveryTag) {
-            cont.resume(returning: ack)
-            confirmedCount += 1
-        }
-
-        // Release waiters if we freed up slots
-        if publisherConfirmationTracking && outstandingConfirmsLimit > 0 {
-            outstandingConfirmsCount -= confirmedCount
-            while !confirmLimitWaiters.isEmpty && outstandingConfirmsCount < outstandingConfirmsLimit {
-                let waiter = confirmLimitWaiters.removeFirst()
-                waiter.resume()
-            }
-        }
-    }
-
-    // MARK: - Private Helpers
-
-    private func removeConsumer(_ tag: String) {
-        consumers[tag]?.finish()
-        consumers.removeValue(forKey: tag)
-    }
-
-    private func sendMethod(_ method: AMQPMethod) async throws {
-        guard let connection = connection else {
-            throw ConnectionError.notConnected
-        }
-        try await connection.send(.method(channelID: channelID, method: method))
-    }
-
-    private func waitForResponse() async throws -> AMQPMethod {
-        try await withCheckedThrowingContinuation { cont in
-            pendingResponses.append(cont)
-        }
-    }
-
-    // MARK: - Close
-
-    public func close() async throws {
-        guard isOpen else { return }
-        isOpen = false
-
-        for continuation in consumers.values {
-            continuation.finish()
-        }
-        consumers.removeAll()
-
-        let close = ChannelClose(replyCode: 200, replyText: "Normal shutdown", classId: 0, methodId: 0)
-        try await sendMethod(.channelClose(close))
-        _ = try? await waitForResponse()
-
-        await connection?.channelClosed(channelID)
-    }
-
-    // MARK: - Properties
-
-    public var open: Bool { isOpen }
-    public var number: UInt16 { channelID }
+  public var open: Bool { isOpen }
+  public var number: UInt16 { channelID }
 }
 
 // MARK: - Supporting Types
 
 public enum ExchangeType: String, Sendable {
-    case direct
-    case fanout
-    case topic
-    case headers
+  case direct
+  case fanout
+  case topic
+  case headers
 }
 
 private struct IncomingMessage {
-    var properties: BasicProperties
-    var bodySize: UInt64
-    var bodyChunks: [Data] = []
-    var receivedBytes: Int = 0
-    var deliveryInfo: DeliveryInfo?
-    var getInfo: GetInfo?
-    var returnInfo: ReturnInfo?
+  var properties: BasicProperties
+  var bodySize: UInt64
+  var bodyChunks: [Data] = []
+  var receivedBytes: Int = 0
+  var deliveryInfo: DeliveryInfo?
+  var getInfo: GetInfo?
+  var returnInfo: ReturnInfo?
 
-    mutating func appendBody(_ chunk: Data) {
-        bodyChunks.append(chunk)
-        receivedBytes += chunk.count
-    }
+  mutating func appendBody(_ chunk: Data) {
+    bodyChunks.append(chunk)
+    receivedBytes += chunk.count
+  }
 
-    func assembleBody() -> Data {
-        guard bodyChunks.count > 1 else {
-            return bodyChunks.first ?? Data()
-        }
-        var result = Data(capacity: receivedBytes)
-        for chunk in bodyChunks {
-            result.append(chunk)
-        }
-        return result
+  func assembleBody() -> Data {
+    guard bodyChunks.count > 1 else {
+      return bodyChunks.first ?? Data()
     }
+    var result = Data(capacity: receivedBytes)
+    for chunk in bodyChunks {
+      result.append(chunk)
+    }
+    return result
+  }
 }
 
 public struct DeliveryInfo: Sendable {
-    public let consumerTag: String
-    public let deliveryTag: UInt64
-    public let redelivered: Bool
-    public let exchange: String
-    public let routingKey: String
+  public let consumerTag: String
+  public let deliveryTag: UInt64
+  public let redelivered: Bool
+  public let exchange: String
+  public let routingKey: String
 }
 
 private struct GetInfo {
-    let deliveryTag: UInt64
-    let redelivered: Bool
-    let exchange: String
-    let routingKey: String
-    let messageCount: UInt32
+  let deliveryTag: UInt64
+  let redelivered: Bool
+  let exchange: String
+  let routingKey: String
+  let messageCount: UInt32
 }
 
 private struct ReturnInfo {
-    let replyCode: UInt16
-    let replyText: String
-    let exchange: String
-    let routingKey: String
+  let replyCode: UInt16
+  let replyText: String
+  let exchange: String
+  let routingKey: String
 }
 
 public struct ChannelCloseInfo: Sendable {
-    public let replyCode: UInt16
-    public let replyText: String
-    public let classID: UInt16
-    public let methodID: UInt16
-    public let initiatedByServer: Bool
+  public let replyCode: UInt16
+  public let replyText: String
+  public let classID: UInt16
+  public let methodID: UInt16
+  public let initiatedByServer: Bool
 
-    public var isSoftError: Bool {
-        AMQPReplyCode(rawValue: replyCode)?.isSoftError ?? false
-    }
+  public var isSoftError: Bool {
+    AMQPReplyCode(rawValue: replyCode)?.isSoftError ?? false
+  }
 
-    public var amqpReplyCode: AMQPReplyCode? {
-        AMQPReplyCode(rawValue: replyCode)
-    }
+  public var amqpReplyCode: AMQPReplyCode? {
+    AMQPReplyCode(rawValue: replyCode)
+  }
 }

--- a/Sources/BunnySwift/Connection.swift
+++ b/Sources/BunnySwift/Connection.swift
@@ -5,228 +5,228 @@
 //
 // Copyright (c) 2025-2026 Michael S. Klishin
 
+@_exported import AMQPProtocol
 import Foundation
 import NIO
 @_exported import Transport
-@_exported import AMQPProtocol
 
 public actor Connection {
-    private let transport: AMQPTransport
-    private let configuration: ConnectionConfiguration
-    private var negotiatedParams: NegotiatedParameters?
-    private var channels: [UInt16: Channel] = [:]
-    private var nextChannelID: UInt16 = 1
-    private var isOpen = false
-    private var blockedReason: String?
+  private let transport: AMQPTransport
+  private let configuration: ConnectionConfiguration
+  private var negotiatedParams: NegotiatedParameters?
+  private var channels: [UInt16: Channel] = [:]
+  private var nextChannelID: UInt16 = 1
+  private var isOpen = false
+  private var blockedReason: String?
 
-    private var onBlockedHandlers: [@Sendable (String) -> Void] = []
-    private var onUnblockedHandlers: [@Sendable () -> Void] = []
-    private var onCloseHandlers: [@Sendable (ConnectionClose) -> Void] = []
+  private var onBlockedHandlers: [@Sendable (String) -> Void] = []
+  private var onUnblockedHandlers: [@Sendable () -> Void] = []
+  private var onCloseHandlers: [@Sendable (ConnectionClose) -> Void] = []
 
-    private init(transport: AMQPTransport, configuration: ConnectionConfiguration) {
-        self.transport = transport
-        self.configuration = configuration
+  private init(transport: AMQPTransport, configuration: ConnectionConfiguration) {
+    self.transport = transport
+    self.configuration = configuration
+  }
+
+  // MARK: - Factory
+
+  public static func open(_ configuration: ConnectionConfiguration) async throws -> Connection {
+    let transport = AMQPTransport()
+    let connection = Connection(transport: transport, configuration: configuration)
+    try await connection.connect()
+    return connection
+  }
+
+  public static func open(uri: String) async throws -> Connection {
+    let configuration = try ConnectionConfiguration.from(uri: uri)
+    return try await open(configuration)
+  }
+
+  public static func open(
+    host: String = "localhost",
+    port: Int = 5672,
+    virtualHost: String = "/",
+    username: String = "guest",
+    password: String = "guest"
+  ) async throws -> Connection {
+    let configuration = ConnectionConfiguration(
+      host: host,
+      port: port,
+      virtualHost: virtualHost,
+      username: username,
+      password: password
+    )
+    return try await open(configuration)
+  }
+
+  private func connect() async throws {
+    let params = try await transport.connect(configuration: configuration)
+    self.negotiatedParams = params
+    self.isOpen = true
+    await startFrameDispatcher()
+  }
+
+  // MARK: - Channels
+
+  public func openChannel() async throws -> Channel {
+    guard isOpen else {
+      throw ConnectionError.notConnected
     }
 
-    // MARK: - Factory
+    let channelID = try allocateChannelID()
+    let channel = Channel(connection: self, channelID: channelID)
+    channels[channelID] = channel
+    do {
+      try await channel.open()
+      return channel
+    } catch {
+      channels.removeValue(forKey: channelID)
+      throw error
+    }
+  }
 
-    public static func open(_ configuration: ConnectionConfiguration) async throws -> Connection {
-        let transport = AMQPTransport()
-        let connection = Connection(transport: transport, configuration: configuration)
-        try await connection.connect()
-        return connection
+  public func withChannel<T: Sendable>(
+    _ operation: (Channel) async throws -> T
+  ) async throws -> T {
+    let channel = try await openChannel()
+    do {
+      let result = try await operation(channel)
+      try await channel.close()
+      return result
+    } catch {
+      try? await channel.close()
+      throw error
+    }
+  }
+
+  private func allocateChannelID() throws -> UInt16 {
+    guard let params = negotiatedParams else {
+      throw ConnectionError.notConnected
     }
 
-    public static func open(uri: String) async throws -> Connection {
-        let configuration = try ConnectionConfiguration.from(uri: uri)
-        return try await open(configuration)
+    let maxChannels = params.channelMax == 0 ? UInt16.max : params.channelMax
+    let startID = nextChannelID
+
+    repeat {
+      if channels[nextChannelID] == nil {
+        let id = nextChannelID
+        advanceChannelID(max: maxChannels)
+        return id
+      }
+      advanceChannelID(max: maxChannels)
+    } while nextChannelID != startID
+
+    throw ConnectionError.protocolError("All \(maxChannels) channel IDs in use")
+  }
+
+  private func advanceChannelID(max: UInt16) {
+    nextChannelID = nextChannelID < max ? nextChannelID + 1 : 1
+  }
+
+  internal func channelClosed(_ channelID: UInt16) {
+    channels.removeValue(forKey: channelID)
+  }
+
+  // MARK: - Frame Dispatch
+
+  private func startFrameDispatcher() async {
+    await transport.setFrameHandler { [weak self] frame in
+      guard let self = self else { return }
+      await self.dispatchFrame(frame)
     }
+  }
 
-    public static func open(
-        host: String = "localhost",
-        port: Int = 5672,
-        virtualHost: String = "/",
-        username: String = "guest",
-        password: String = "guest"
-    ) async throws -> Connection {
-        let configuration = ConnectionConfiguration(
-            host: host,
-            port: port,
-            virtualHost: virtualHost,
-            username: username,
-            password: password
-        )
-        return try await open(configuration)
+  private func dispatchFrame(_ frame: Frame) async {
+    switch frame {
+    case .method(channelID: 0, let method):
+      await handleConnectionMethod(method)
+    case .method(let channelID, method: _),
+      .header(let channelID, _, _, _),
+      .body(let channelID, _):
+      if let channel = channels[channelID] {
+        await channel.handleFrame(frame)
+      }
+    case .heartbeat:
+      break
     }
+  }
 
-    private func connect() async throws {
-        let params = try await transport.connect(configuration: configuration)
-        self.negotiatedParams = params
-        self.isOpen = true
-        await startFrameDispatcher()
+  private func handleConnectionMethod(_ method: AMQPMethod) async {
+    switch method {
+    case .connectionClose(let close):
+      for handler in onCloseHandlers { handler(close) }
+      isOpen = false
+      try? await transport.send(.method(channelID: 0, method: .connectionCloseOk))
+      await transport.forceClose()
+
+    case .connectionBlocked(let blocked):
+      blockedReason = blocked.reason
+      for handler in onBlockedHandlers { handler(blocked.reason) }
+
+    case .connectionUnblocked:
+      blockedReason = nil
+      for handler in onUnblockedHandlers { handler() }
+
+    default:
+      break
     }
+  }
 
-    // MARK: - Channels
+  // MARK: - Frame I/O
 
-    public func openChannel() async throws -> Channel {
-        guard isOpen else {
-            throw ConnectionError.notConnected
-        }
+  internal func send(_ frame: Frame) async throws {
+    guard isOpen else { throw ConnectionError.notConnected }
+    try await transport.send(frame)
+  }
 
-        let channelID = try allocateChannelID()
-        let channel = Channel(connection: self, channelID: channelID)
-        channels[channelID] = channel
-        do {
-            try await channel.open()
-            return channel
-        } catch {
-            channels.removeValue(forKey: channelID)
-            throw error
-        }
+  internal func write(_ frame: Frame) async throws {
+    guard isOpen else { throw ConnectionError.notConnected }
+    try await transport.write(frame)
+  }
+
+  internal func writeBatch(_ frames: [Frame]) async throws {
+    guard isOpen else { throw ConnectionError.notConnected }
+    try await transport.writeBatch(frames)
+  }
+
+  internal func flush() async {
+    await transport.flush()
+  }
+
+  // MARK: - Events
+
+  public func onBlocked(_ handler: @escaping @Sendable (String) -> Void) {
+    onBlockedHandlers.append(handler)
+  }
+
+  public func onUnblocked(_ handler: @escaping @Sendable () -> Void) {
+    onUnblockedHandlers.append(handler)
+  }
+
+  public func onClose(_ handler: @escaping @Sendable (ConnectionClose) -> Void) {
+    onCloseHandlers.append(handler)
+  }
+
+  // MARK: - Close
+
+  public func close() async throws {
+    guard isOpen else { return }
+    isOpen = false
+
+    for channel in channels.values {
+      try? await channel.close()
     }
+    channels.removeAll()
+    await transport.close()
+  }
 
-    public func withChannel<T: Sendable>(
-        _ operation: (Channel) async throws -> T
-    ) async throws -> T {
-        let channel = try await openChannel()
-        do {
-            let result = try await operation(channel)
-            try await channel.close()
-            return result
-        } catch {
-            try? await channel.close()
-            throw error
-        }
-    }
+  // MARK: - Properties
 
-    private func allocateChannelID() throws -> UInt16 {
-        guard let params = negotiatedParams else {
-            throw ConnectionError.notConnected
-        }
-
-        let maxChannels = params.channelMax == 0 ? UInt16.max : params.channelMax
-        let startID = nextChannelID
-
-        repeat {
-            if channels[nextChannelID] == nil {
-                let id = nextChannelID
-                advanceChannelID(max: maxChannels)
-                return id
-            }
-            advanceChannelID(max: maxChannels)
-        } while nextChannelID != startID
-
-        throw ConnectionError.protocolError("All \(maxChannels) channel IDs in use")
-    }
-
-    private func advanceChannelID(max: UInt16) {
-        nextChannelID = nextChannelID < max ? nextChannelID + 1 : 1
-    }
-
-    internal func channelClosed(_ channelID: UInt16) {
-        channels.removeValue(forKey: channelID)
-    }
-
-    // MARK: - Frame Dispatch
-
-    private func startFrameDispatcher() async {
-        await transport.setFrameHandler { [weak self] frame in
-            guard let self = self else { return }
-            await self.dispatchFrame(frame)
-        }
-    }
-
-    private func dispatchFrame(_ frame: Frame) async {
-        switch frame {
-        case .method(channelID: 0, method: let method):
-            await handleConnectionMethod(method)
-        case .method(channelID: let channelID, method: _),
-             .header(channelID: let channelID, _, _, _),
-             .body(channelID: let channelID, _):
-            if let channel = channels[channelID] {
-                await channel.handleFrame(frame)
-            }
-        case .heartbeat:
-            break
-        }
-    }
-
-    private func handleConnectionMethod(_ method: AMQPMethod) async {
-        switch method {
-        case .connectionClose(let close):
-            for handler in onCloseHandlers { handler(close) }
-            isOpen = false
-            try? await transport.send(.method(channelID: 0, method: .connectionCloseOk))
-            await transport.forceClose()
-
-        case .connectionBlocked(let blocked):
-            blockedReason = blocked.reason
-            for handler in onBlockedHandlers { handler(blocked.reason) }
-
-        case .connectionUnblocked:
-            blockedReason = nil
-            for handler in onUnblockedHandlers { handler() }
-
-        default:
-            break
-        }
-    }
-
-    // MARK: - Frame I/O
-
-    internal func send(_ frame: Frame) async throws {
-        guard isOpen else { throw ConnectionError.notConnected }
-        try await transport.send(frame)
-    }
-
-    internal func write(_ frame: Frame) async throws {
-        guard isOpen else { throw ConnectionError.notConnected }
-        try await transport.write(frame)
-    }
-
-    internal func writeBatch(_ frames: [Frame]) async throws {
-        guard isOpen else { throw ConnectionError.notConnected }
-        try await transport.writeBatch(frames)
-    }
-
-    internal func flush() async {
-        await transport.flush()
-    }
-
-    // MARK: - Events
-
-    public func onBlocked(_ handler: @escaping @Sendable (String) -> Void) {
-        onBlockedHandlers.append(handler)
-    }
-
-    public func onUnblocked(_ handler: @escaping @Sendable () -> Void) {
-        onUnblockedHandlers.append(handler)
-    }
-
-    public func onClose(_ handler: @escaping @Sendable (ConnectionClose) -> Void) {
-        onCloseHandlers.append(handler)
-    }
-
-    // MARK: - Close
-
-    public func close() async throws {
-        guard isOpen else { return }
-        isOpen = false
-
-        for channel in channels.values {
-            try? await channel.close()
-        }
-        channels.removeAll()
-        await transport.close()
-    }
-
-    // MARK: - Properties
-
-    public var connected: Bool { isOpen }
-    public var blocked: Bool { blockedReason != nil }
-    public var blockedMessage: String? { blockedReason }
-    public var serverProperties: Table? { negotiatedParams?.serverProperties }
-    public var frameMax: UInt32 { negotiatedParams?.frameMax ?? FrameDefaults.maxSize }
-    public var heartbeat: UInt16 { negotiatedParams?.heartbeat ?? 60 }
-    public var channelMax: UInt16 { negotiatedParams?.channelMax ?? 2047 }
+  public var connected: Bool { isOpen }
+  public var blocked: Bool { blockedReason != nil }
+  public var blockedMessage: String? { blockedReason }
+  public var serverProperties: Table? { negotiatedParams?.serverProperties }
+  public var frameMax: UInt32 { negotiatedParams?.frameMax ?? FrameDefaults.maxSize }
+  public var heartbeat: UInt16 { negotiatedParams?.heartbeat ?? 60 }
+  public var channelMax: UInt16 { negotiatedParams?.channelMax ?? 2047 }
 }

--- a/Sources/BunnySwift/Exchange.swift
+++ b/Sources/BunnySwift/Exchange.swift
@@ -5,81 +5,95 @@
 //
 // Copyright (c) 2025-2026 Michael S. Klishin
 
-import Foundation
 import AMQPProtocol
+import Foundation
 
 public struct Exchange: Sendable {
-    public let name: String
-    public let type: ExchangeType
-    private let channel: Channel
+  public let name: String
+  public let type: ExchangeType
+  private let channel: Channel
 
-    internal init(channel: Channel, name: String, type: ExchangeType) {
-        self.channel = channel
-        self.name = name
-        self.type = type
+  internal init(channel: Channel, name: String, type: ExchangeType) {
+    self.channel = channel
+    self.name = name
+    self.type = type
+  }
+
+  // MARK: - Publishing
+
+  public func publish(
+    _ body: Data,
+    routingKey: String = "",
+    mandatory: Bool = false,
+    immediate: Bool = false,
+    properties: BasicProperties = .persistent
+  ) async throws {
+    try await channel.basicPublish(
+      body: body,
+      exchange: name,
+      routingKey: routingKey,
+      mandatory: mandatory,
+      immediate: immediate,
+      properties: properties
+    )
+  }
+
+  public func publish(
+    _ message: String,
+    routingKey: String = "",
+    mandatory: Bool = false,
+    immediate: Bool = false,
+    properties: BasicProperties = .persistent
+  ) async throws {
+    guard let data = message.data(using: .utf8) else {
+      throw ConnectionError.protocolError("Failed to encode message as UTF-8")
     }
+    try await publish(
+      data, routingKey: routingKey, mandatory: mandatory, immediate: immediate,
+      properties: properties)
+  }
 
-    // MARK: - Publishing
+  // MARK: - Binding
 
-    public func publish(
-        _ body: Data,
-        routingKey: String = "",
-        mandatory: Bool = false,
-        immediate: Bool = false,
-        properties: BasicProperties = .persistent
-    ) async throws {
-        try await channel.basicPublish(
-            body: body,
-            exchange: name,
-            routingKey: routingKey,
-            mandatory: mandatory,
-            immediate: immediate,
-            properties: properties
-        )
-    }
+  @discardableResult
+  public func bind(to source: Exchange, routingKey: String = "", arguments: Table = [:])
+    async throws -> Exchange
+  {
+    try await channel.exchangeBind(
+      destination: name, source: source.name, routingKey: routingKey, arguments: arguments)
+    return self
+  }
 
-    public func publish(
-        _ message: String,
-        routingKey: String = "",
-        mandatory: Bool = false,
-        immediate: Bool = false,
-        properties: BasicProperties = .persistent
-    ) async throws {
-        guard let data = message.data(using: .utf8) else {
-            throw ConnectionError.protocolError("Failed to encode message as UTF-8")
-        }
-        try await publish(data, routingKey: routingKey, mandatory: mandatory, immediate: immediate, properties: properties)
-    }
+  @discardableResult
+  public func bind(to sourceName: String, routingKey: String = "", arguments: Table = [:])
+    async throws -> Exchange
+  {
+    try await channel.exchangeBind(
+      destination: name, source: sourceName, routingKey: routingKey, arguments: arguments)
+    return self
+  }
 
-    // MARK: - Binding
+  @discardableResult
+  public func unbind(from source: Exchange, routingKey: String = "", arguments: Table = [:])
+    async throws -> Exchange
+  {
+    try await channel.exchangeUnbind(
+      destination: name, source: source.name, routingKey: routingKey, arguments: arguments)
+    return self
+  }
 
-    @discardableResult
-    public func bind(to source: Exchange, routingKey: String = "", arguments: Table = [:]) async throws -> Exchange {
-        try await channel.exchangeBind(destination: name, source: source.name, routingKey: routingKey, arguments: arguments)
-        return self
-    }
+  @discardableResult
+  public func unbind(from sourceName: String, routingKey: String = "", arguments: Table = [:])
+    async throws -> Exchange
+  {
+    try await channel.exchangeUnbind(
+      destination: name, source: sourceName, routingKey: routingKey, arguments: arguments)
+    return self
+  }
 
-    @discardableResult
-    public func bind(to sourceName: String, routingKey: String = "", arguments: Table = [:]) async throws -> Exchange {
-        try await channel.exchangeBind(destination: name, source: sourceName, routingKey: routingKey, arguments: arguments)
-        return self
-    }
+  // MARK: - Management
 
-    @discardableResult
-    public func unbind(from source: Exchange, routingKey: String = "", arguments: Table = [:]) async throws -> Exchange {
-        try await channel.exchangeUnbind(destination: name, source: source.name, routingKey: routingKey, arguments: arguments)
-        return self
-    }
-
-    @discardableResult
-    public func unbind(from sourceName: String, routingKey: String = "", arguments: Table = [:]) async throws -> Exchange {
-        try await channel.exchangeUnbind(destination: name, source: sourceName, routingKey: routingKey, arguments: arguments)
-        return self
-    }
-
-    // MARK: - Management
-
-    public func delete(ifUnused: Bool = false) async throws {
-        try await channel.exchangeDelete(name, ifUnused: ifUnused)
-    }
+  public func delete(ifUnused: Bool = false) async throws {
+    try await channel.exchangeDelete(name, ifUnused: ifUnused)
+  }
 }

--- a/Sources/BunnySwift/Message.swift
+++ b/Sources/BunnySwift/Message.swift
@@ -5,39 +5,42 @@
 //
 // Copyright (c) 2025-2026 Michael S. Klishin
 
-import Foundation
 import AMQPProtocol
+import Foundation
 
 // MARK: - Message
 
 public struct Message: Sendable {
-    public let body: Data
-    public let properties: BasicProperties
-    public let deliveryInfo: DeliveryInfo
-    private let channel: Channel
+  public let body: Data
+  public let properties: BasicProperties
+  public let deliveryInfo: DeliveryInfo
+  private let channel: Channel
 
-    internal init(body: Data, properties: BasicProperties, deliveryInfo: DeliveryInfo, channel: Channel) {
-        self.body = body
-        self.properties = properties
-        self.deliveryInfo = deliveryInfo
-        self.channel = channel
-    }
+  internal init(
+    body: Data, properties: BasicProperties, deliveryInfo: DeliveryInfo, channel: Channel
+  ) {
+    self.body = body
+    self.properties = properties
+    self.deliveryInfo = deliveryInfo
+    self.channel = channel
+  }
 
-    public func ack(multiple: Bool = false) async throws {
-        try await channel.basicAck(deliveryTag: deliveryInfo.deliveryTag, multiple: multiple)
-    }
+  public func ack(multiple: Bool = false) async throws {
+    try await channel.basicAck(deliveryTag: deliveryInfo.deliveryTag, multiple: multiple)
+  }
 
-    public func nack(multiple: Bool = false, requeue: Bool = true) async throws {
-        try await channel.basicNack(deliveryTag: deliveryInfo.deliveryTag, multiple: multiple, requeue: requeue)
-    }
+  public func nack(multiple: Bool = false, requeue: Bool = true) async throws {
+    try await channel.basicNack(
+      deliveryTag: deliveryInfo.deliveryTag, multiple: multiple, requeue: requeue)
+  }
 
-    public func reject(requeue: Bool = true) async throws {
-        try await channel.basicReject(deliveryTag: deliveryInfo.deliveryTag, requeue: requeue)
-    }
+  public func reject(requeue: Bool = true) async throws {
+    try await channel.basicReject(deliveryTag: deliveryInfo.deliveryTag, requeue: requeue)
+  }
 
-    public var bodyString: String? {
-        String(data: body, encoding: .utf8)
-    }
+  public var bodyString: String? {
+    String(data: body, encoding: .utf8)
+  }
 }
 
 // MARK: - GetResponse
@@ -46,94 +49,94 @@ public struct Message: Sendable {
 /// - Danger: never to be used in production. See `basicConsume` (long-running subscriptions).
 @_documentation(visibility: private)
 public struct GetResponse: Sendable {
-    public let body: Data
-    public let properties: BasicProperties
-    public let deliveryTag: UInt64
-    public let redelivered: Bool
-    public let exchange: String
-    public let routingKey: String
-    public let messageCount: UInt32
-    private let channel: Channel
+  public let body: Data
+  public let properties: BasicProperties
+  public let deliveryTag: UInt64
+  public let redelivered: Bool
+  public let exchange: String
+  public let routingKey: String
+  public let messageCount: UInt32
+  private let channel: Channel
 
-    internal init(
-        body: Data,
-        properties: BasicProperties,
-        deliveryTag: UInt64,
-        redelivered: Bool,
-        exchange: String,
-        routingKey: String,
-        messageCount: UInt32,
-        channel: Channel
-    ) {
-        self.body = body
-        self.properties = properties
-        self.deliveryTag = deliveryTag
-        self.redelivered = redelivered
-        self.exchange = exchange
-        self.routingKey = routingKey
-        self.messageCount = messageCount
-        self.channel = channel
-    }
+  internal init(
+    body: Data,
+    properties: BasicProperties,
+    deliveryTag: UInt64,
+    redelivered: Bool,
+    exchange: String,
+    routingKey: String,
+    messageCount: UInt32,
+    channel: Channel
+  ) {
+    self.body = body
+    self.properties = properties
+    self.deliveryTag = deliveryTag
+    self.redelivered = redelivered
+    self.exchange = exchange
+    self.routingKey = routingKey
+    self.messageCount = messageCount
+    self.channel = channel
+  }
 
-    public func ack(multiple: Bool = false) async throws {
-        try await channel.basicAck(deliveryTag: deliveryTag, multiple: multiple)
-    }
+  public func ack(multiple: Bool = false) async throws {
+    try await channel.basicAck(deliveryTag: deliveryTag, multiple: multiple)
+  }
 
-    public func nack(multiple: Bool = false, requeue: Bool = true) async throws {
-        try await channel.basicNack(deliveryTag: deliveryTag, multiple: multiple, requeue: requeue)
-    }
+  public func nack(multiple: Bool = false, requeue: Bool = true) async throws {
+    try await channel.basicNack(deliveryTag: deliveryTag, multiple: multiple, requeue: requeue)
+  }
 
-    public func reject(requeue: Bool = true) async throws {
-        try await channel.basicReject(deliveryTag: deliveryTag, requeue: requeue)
-    }
+  public func reject(requeue: Bool = true) async throws {
+    try await channel.basicReject(deliveryTag: deliveryTag, requeue: requeue)
+  }
 
-    public var bodyString: String? {
-        String(data: body, encoding: .utf8)
-    }
+  public var bodyString: String? {
+    String(data: body, encoding: .utf8)
+  }
 }
 
 // MARK: - ReturnedMessage
 
 public struct ReturnedMessage: Sendable {
-    public let body: Data
-    public let properties: BasicProperties
-    public let replyCode: UInt16
-    public let replyText: String
-    public let exchange: String
-    public let routingKey: String
+  public let body: Data
+  public let properties: BasicProperties
+  public let replyCode: UInt16
+  public let replyText: String
+  public let exchange: String
+  public let routingKey: String
 
-    public var bodyString: String? {
-        String(data: body, encoding: .utf8)
-    }
+  public var bodyString: String? {
+    String(data: body, encoding: .utf8)
+  }
 }
 
 // MARK: - MessageStream
 
 public struct MessageStream: AsyncSequence, Sendable {
-    public typealias Element = Message
-    public let consumerTag: String
-    private let channel: Channel
-    private let stream: AsyncStream<Message>
+  public typealias Element = Message
+  public let consumerTag: String
+  private let channel: Channel
+  private let stream: AsyncStream<Message>
 
-    internal init(channel: Channel, consumerTag: String, stream: AsyncStream<Message>) {
-        self.channel = channel
-        self.consumerTag = consumerTag
-        self.stream = stream
+  internal init(channel: Channel, consumerTag: String, stream: AsyncStream<Message>) {
+    self.channel = channel
+    self.consumerTag = consumerTag
+    self.stream = stream
+  }
+
+  public func makeAsyncIterator() -> AsyncIterator {
+    AsyncIterator(iterator: stream.makeAsyncIterator())
+  }
+
+  public func cancel() async throws {
+    try await channel.basicCancel(consumerTag)
+  }
+
+  public struct AsyncIterator: AsyncIteratorProtocol {
+    var iterator: AsyncStream<Message>.AsyncIterator
+
+    public mutating func next() async -> Message? {
+      await iterator.next()
     }
-
-    public func makeAsyncIterator() -> AsyncIterator {
-        AsyncIterator(iterator: stream.makeAsyncIterator())
-    }
-
-    public func cancel() async throws {
-        try await channel.basicCancel(consumerTag)
-    }
-
-    public struct AsyncIterator: AsyncIteratorProtocol {
-        var iterator: AsyncStream<Message>.AsyncIterator
-
-        public mutating func next() async -> Message? {
-            await iterator.next()
-        }
-    }
+  }
 }

--- a/Sources/BunnySwift/Queue.swift
+++ b/Sources/BunnySwift/Queue.swift
@@ -5,144 +5,159 @@
 //
 // Copyright (c) 2025-2026 Michael S. Klishin
 
-import Foundation
 import AMQPProtocol
+import Foundation
 
 /// Queue type determines the queue implementation used by RabbitMQ.
 ///
 /// See [Queue Types](https://www.rabbitmq.com/docs/queues#queue-types) for details.
 public enum QueueType: Sendable, Hashable {
-    /// Classic queues
-    case classic
-    /// Quorum queues: replicated, durable queues
-    case quorum
-    /// Streams: replicated append-only log with non-destructive consumption.
-    /// AMQP 0-9-1 clients such as BunnySwift can only use certain basic stream features;
-    /// consider using a RabbitMQ Stream Protocol client instead.
-    case stream
-    /// Custom or plugin-provided queue types.
-    case custom(String)
+  /// Classic queues
+  case classic
+  /// Quorum queues: replicated, durable queues
+  case quorum
+  /// Streams: replicated append-only log with non-destructive consumption.
+  /// AMQP 0-9-1 clients such as BunnySwift can only use certain basic stream features;
+  /// consider using a RabbitMQ Stream Protocol client instead.
+  case stream
+  /// Custom or plugin-provided queue types.
+  case custom(String)
 
-    /// The string value sent to RabbitMQ
-    public var rawValue: String {
-        switch self {
-        case .classic: return "classic"
-        case .quorum: return "quorum"
-        case .stream: return "stream"
-        case .custom(let value): return value
-        }
+  /// The string value sent to RabbitMQ
+  public var rawValue: String {
+    switch self {
+    case .classic: return "classic"
+    case .quorum: return "quorum"
+    case .stream: return "stream"
+    case .custom(let value): return value
     }
+  }
 
-    /// Converts to the AMQP 0-9-1 table value for the `x-queue-type` argument
-    public var asTableValue: FieldValue {
-        .string(rawValue)
-    }
+  /// Converts to the AMQP 0-9-1 table value for the `x-queue-type` argument
+  public var asTableValue: FieldValue {
+    .string(rawValue)
+  }
 }
 
 public struct Queue: Sendable {
-    public let name: String
-    public let messageCount: UInt32
-    public let consumerCount: UInt32
-    private let channel: Channel
+  public let name: String
+  public let messageCount: UInt32
+  public let consumerCount: UInt32
+  private let channel: Channel
 
-    internal init(channel: Channel, name: String, messageCount: UInt32 = 0, consumerCount: UInt32 = 0) {
-        self.channel = channel
-        self.name = name
-        self.messageCount = messageCount
-        self.consumerCount = consumerCount
+  internal init(channel: Channel, name: String, messageCount: UInt32 = 0, consumerCount: UInt32 = 0)
+  {
+    self.channel = channel
+    self.name = name
+    self.messageCount = messageCount
+    self.consumerCount = consumerCount
+  }
+
+  // MARK: - Binding
+
+  @discardableResult
+  public func bind(to exchange: Exchange, routingKey: String = "", arguments: Table = [:])
+    async throws -> Queue
+  {
+    try await channel.queueBind(
+      queue: name, exchange: exchange.name, routingKey: routingKey, arguments: arguments)
+    return self
+  }
+
+  @discardableResult
+  public func bind(to exchangeName: String, routingKey: String = "", arguments: Table = [:])
+    async throws -> Queue
+  {
+    try await channel.queueBind(
+      queue: name, exchange: exchangeName, routingKey: routingKey, arguments: arguments)
+    return self
+  }
+
+  @discardableResult
+  public func unbind(from exchange: Exchange, routingKey: String = "", arguments: Table = [:])
+    async throws -> Queue
+  {
+    try await channel.queueUnbind(
+      queue: name, exchange: exchange.name, routingKey: routingKey, arguments: arguments)
+    return self
+  }
+
+  @discardableResult
+  public func unbind(from exchangeName: String, routingKey: String = "", arguments: Table = [:])
+    async throws -> Queue
+  {
+    try await channel.queueUnbind(
+      queue: name, exchange: exchangeName, routingKey: routingKey, arguments: arguments)
+    return self
+  }
+
+  // MARK: - Consuming
+
+  public func consume(
+    consumerTag: String = "",
+    acknowledgementMode: ConsumerAcknowledgementMode = .manual,
+    exclusive: Bool = false,
+    arguments: Table = [:]
+  ) async throws -> MessageStream {
+    try await channel.basicConsume(
+      queue: name,
+      consumerTag: consumerTag,
+      acknowledgementMode: acknowledgementMode,
+      exclusive: exclusive,
+      arguments: arguments
+    )
+  }
+
+  /// Synchronously fetch a single message from this queue (pull API).
+  ///
+  /// - Warning: This method is inefficient and strongly discouraged for production use.
+  ///   Use ``consume(consumerTag:acknowledgementMode:exclusive:arguments:)`` instead.
+  ///
+  /// Suitable only for tests, debugging, or administrative tools.
+  @_documentation(visibility: private)
+  public func get(acknowledgementMode: ConsumerAcknowledgementMode = .manual) async throws
+    -> GetResponse?
+  {
+    try await channel.basicGet(queue: name, acknowledgementMode: acknowledgementMode)
+  }
+
+  // MARK: - Publishing
+
+  /// Uses default exchange with queue name as routing key
+  public func publish(
+    _ body: Data,
+    properties: BasicProperties = .persistent,
+    mandatory: Bool = false
+  ) async throws {
+    try await channel.basicPublish(
+      body: body,
+      exchange: "",
+      routingKey: name,
+      mandatory: mandatory,
+      properties: properties
+    )
+  }
+
+  public func publish(
+    _ message: String,
+    properties: BasicProperties = .persistent,
+    mandatory: Bool = false
+  ) async throws {
+    guard let data = message.data(using: .utf8) else {
+      throw ConnectionError.protocolError("Failed to encode message as UTF-8")
     }
+    try await publish(data, properties: properties, mandatory: mandatory)
+  }
 
-    // MARK: - Binding
+  // MARK: - Management
 
-    @discardableResult
-    public func bind(to exchange: Exchange, routingKey: String = "", arguments: Table = [:]) async throws -> Queue {
-        try await channel.queueBind(queue: name, exchange: exchange.name, routingKey: routingKey, arguments: arguments)
-        return self
-    }
+  /// Returns number of messages purged
+  public func purge() async throws -> UInt32 {
+    try await channel.queuePurge(name)
+  }
 
-    @discardableResult
-    public func bind(to exchangeName: String, routingKey: String = "", arguments: Table = [:]) async throws -> Queue {
-        try await channel.queueBind(queue: name, exchange: exchangeName, routingKey: routingKey, arguments: arguments)
-        return self
-    }
-
-    @discardableResult
-    public func unbind(from exchange: Exchange, routingKey: String = "", arguments: Table = [:]) async throws -> Queue {
-        try await channel.queueUnbind(queue: name, exchange: exchange.name, routingKey: routingKey, arguments: arguments)
-        return self
-    }
-
-    @discardableResult
-    public func unbind(from exchangeName: String, routingKey: String = "", arguments: Table = [:]) async throws -> Queue {
-        try await channel.queueUnbind(queue: name, exchange: exchangeName, routingKey: routingKey, arguments: arguments)
-        return self
-    }
-
-    // MARK: - Consuming
-
-    public func consume(
-        consumerTag: String = "",
-        acknowledgementMode: ConsumerAcknowledgementMode = .manual,
-        exclusive: Bool = false,
-        arguments: Table = [:]
-    ) async throws -> MessageStream {
-        try await channel.basicConsume(
-            queue: name,
-            consumerTag: consumerTag,
-            acknowledgementMode: acknowledgementMode,
-            exclusive: exclusive,
-            arguments: arguments
-        )
-    }
-
-    /// Synchronously fetch a single message from this queue (pull API).
-    ///
-    /// - Warning: This method is inefficient and strongly discouraged for production use.
-    ///   Use ``consume(consumerTag:acknowledgementMode:exclusive:arguments:)`` instead.
-    ///
-    /// Suitable only for tests, debugging, or administrative tools.
-    @_documentation(visibility: private)
-    public func get(acknowledgementMode: ConsumerAcknowledgementMode = .manual) async throws -> GetResponse? {
-        try await channel.basicGet(queue: name, acknowledgementMode: acknowledgementMode)
-    }
-
-    // MARK: - Publishing
-
-    /// Uses default exchange with queue name as routing key
-    public func publish(
-        _ body: Data,
-        properties: BasicProperties = .persistent,
-        mandatory: Bool = false
-    ) async throws {
-        try await channel.basicPublish(
-            body: body,
-            exchange: "",
-            routingKey: name,
-            mandatory: mandatory,
-            properties: properties
-        )
-    }
-
-    public func publish(
-        _ message: String,
-        properties: BasicProperties = .persistent,
-        mandatory: Bool = false
-    ) async throws {
-        guard let data = message.data(using: .utf8) else {
-            throw ConnectionError.protocolError("Failed to encode message as UTF-8")
-        }
-        try await publish(data, properties: properties, mandatory: mandatory)
-    }
-
-    // MARK: - Management
-
-    /// Returns number of messages purged
-    public func purge() async throws -> UInt32 {
-        try await channel.queuePurge(name)
-    }
-
-    /// Returns number of messages deleted
-    public func delete(ifUnused: Bool = false, ifEmpty: Bool = false) async throws -> UInt32 {
-        try await channel.queueDelete(name, ifUnused: ifUnused, ifEmpty: ifEmpty)
-    }
+  /// Returns number of messages deleted
+  public func delete(ifUnused: Bool = false, ifEmpty: Bool = false) async throws -> UInt32 {
+    try await channel.queueDelete(name, ifUnused: ifUnused, ifEmpty: ifEmpty)
+  }
 }

--- a/Sources/BunnySwift/XArguments.swift
+++ b/Sources/BunnySwift/XArguments.swift
@@ -10,113 +10,113 @@
 /// See [Queue Arguments](https://www.rabbitmq.com/docs/queues#optional-arguments)
 /// to learn more.
 public enum XArguments {
-    // MARK: - Queue Types
+  // MARK: - Queue Types
 
-    /// Queue type argument key
-    public static let queueType = "x-queue-type"
+  /// Queue type argument key
+  public static let queueType = "x-queue-type"
 
-    // MARK: - TTL and Expiration
+  // MARK: - TTL and Expiration
 
-    /// Per-message TTL in milliseconds
-    public static let messageTTL = "x-message-ttl"
+  /// Per-message TTL in milliseconds
+  public static let messageTTL = "x-message-ttl"
 
-    /// Queue expiration (TTL) in milliseconds.
-    /// The queue will be deleted after this time of being unused.
-    public static let expires = "x-expires"
+  /// Queue expiration (TTL) in milliseconds.
+  /// The queue will be deleted after this time of being unused.
+  public static let expires = "x-expires"
 
-    // MARK: - Length Limits
+  // MARK: - Length Limits
 
-    /// Maximum number of messages in the queue
-    public static let maxLength = "x-max-length"
+  /// Maximum number of messages in the queue
+  public static let maxLength = "x-max-length"
 
-    /// Maximum total size of messages in bytes
-    public static let maxLengthBytes = "x-max-length-bytes"
+  /// Maximum total size of messages in bytes
+  public static let maxLengthBytes = "x-max-length-bytes"
 
-    // MARK: - Dead Lettering
+  // MARK: - Dead Lettering
 
-    /// Dead letter exchange name
-    public static let deadLetterExchange = "x-dead-letter-exchange"
+  /// Dead letter exchange name
+  public static let deadLetterExchange = "x-dead-letter-exchange"
 
-    /// Dead letter routing key
-    public static let deadLetterRoutingKey = "x-dead-letter-routing-key"
+  /// Dead letter routing key
+  public static let deadLetterRoutingKey = "x-dead-letter-routing-key"
 
-    /// Dead letter strategy ("at-most-once" or "at-least-once")
-    public static let deadLetterStrategy = "x-dead-letter-strategy"
+  /// Dead letter strategy ("at-most-once" or "at-least-once")
+  public static let deadLetterStrategy = "x-dead-letter-strategy"
 
-    // MARK: - Overflow Behavior
+  // MARK: - Overflow Behavior
 
-    /// Overflow behavior when queue length limit is reached.
-    /// Values: "drop-head", "reject-publish", "reject-publish-dlx"
-    public static let overflow = "x-overflow"
+  /// Overflow behavior when queue length limit is reached.
+  /// Values: "drop-head", "reject-publish", "reject-publish-dlx"
+  public static let overflow = "x-overflow"
 
-    // MARK: - Priority Queues
+  // MARK: - Priority Queues
 
-    /// Maximum priority level
-    public static let maxPriority = "x-max-priority"
+  /// Maximum priority level
+  public static let maxPriority = "x-max-priority"
 
-    // MARK: - Consumer Options
+  // MARK: - Consumer Options
 
-    /// Enable single active consumer mode
-    public static let singleActiveConsumer = "x-single-active-consumer"
+  /// Enable single active consumer mode
+  public static let singleActiveConsumer = "x-single-active-consumer"
 
-    // MARK: - Queue Leader Locator
+  // MARK: - Queue Leader Locator
 
-    /// Queue leader locator strategy.
-    /// Values: "client-local", "balanced"
-    public static let queueLeaderLocator = "x-queue-leader-locator"
+  /// Queue leader locator strategy.
+  /// Values: "client-local", "balanced"
+  public static let queueLeaderLocator = "x-queue-leader-locator"
 
-    // MARK: - Quorum Queue Options
+  // MARK: - Quorum Queue Options
 
-    /// Initial quorum group size for quorum queues
-    public static let quorumInitialGroupSize = "x-quorum-initial-group-size"
+  /// Initial quorum group size for quorum queues
+  public static let quorumInitialGroupSize = "x-quorum-initial-group-size"
 
-    /// Target quorum group size for quorum queues
-    public static let quorumTargetGroupSize = "x-quorum-target-group-size"
+  /// Target quorum group size for quorum queues
+  public static let quorumTargetGroupSize = "x-quorum-target-group-size"
 
-    /// Delivery limit before dead-lettering (quorum queues)
-    public static let deliveryLimit = "x-delivery-limit"
+  /// Delivery limit before dead-lettering (quorum queues)
+  public static let deliveryLimit = "x-delivery-limit"
 
-    // MARK: - Stream Options
+  // MARK: - Stream Options
 
-    /// Maximum age for stream retention (e.g., "7D", "1h")
-    public static let maxAge = "x-max-age"
+  /// Maximum age for stream retention (e.g., "7D", "1h")
+  public static let maxAge = "x-max-age"
 
-    /// Maximum segment size in bytes for streams
-    public static let streamMaxSegmentSizeBytes = "x-stream-max-segment-size-bytes"
+  /// Maximum segment size in bytes for streams
+  public static let streamMaxSegmentSizeBytes = "x-stream-max-segment-size-bytes"
 
-    /// Bloom filter size in bytes for streams (16-255)
-    public static let streamFilterSizeBytes = "x-stream-filter-size-bytes"
+  /// Bloom filter size in bytes for streams (16-255)
+  public static let streamFilterSizeBytes = "x-stream-filter-size-bytes"
 
-    /// Initial cluster size for streams
-    public static let initialClusterSize = "x-initial-cluster-size"
+  /// Initial cluster size for streams
+  public static let initialClusterSize = "x-initial-cluster-size"
 
-    /// Stream offset specification for consumers
-    public static let streamOffset = "x-stream-offset"
+  /// Stream offset specification for consumers
+  public static let streamOffset = "x-stream-offset"
 }
 
 /// Standard overflow behavior values for the `x-overflow` argument.
 public enum OverflowBehavior: String, Sendable {
-    /// Drop messages from the head of the queue
-    case dropHead = "drop-head"
-    /// Reject new publishes with basic.nack responses (publisher confirms)
-    case rejectPublish = "reject-publish"
-    /// Reject new publishes via publisher confirms and dead-letter them
-    case rejectPublishDLX = "reject-publish-dlx"
+  /// Drop messages from the head of the queue
+  case dropHead = "drop-head"
+  /// Reject new publishes with basic.nack responses (publisher confirms)
+  case rejectPublish = "reject-publish"
+  /// Reject new publishes via publisher confirms and dead-letter them
+  case rejectPublishDLX = "reject-publish-dlx"
 }
 
 /// Queue leader locator strategies for the `x-queue-leader-locator` argument.
 public enum QueueLeaderLocator: String, Sendable {
-    /// Place leader on the node the client is connected to
-    case clientLocal = "client-local"
-    /// Dynamically picks one of the two strategies internally depending on how many
-    // queues there are in the system
-    case balanced = "balanced"
+  /// Place leader on the node the client is connected to
+  case clientLocal = "client-local"
+  /// Dynamically picks one of the two strategies internally depending on how many
+  // queues there are in the system
+  case balanced = "balanced"
 }
 
 /// Dead letter strategy for the `x-dead-letter-strategy` argument.
 public enum DeadLetterStrategy: String, Sendable {
-    /// At most once delivery, less safe but more performant
-    case atMostOnce = "at-most-once"
-    /// At least once delivery, safe, less performance, quorum queues-specific
-    case atLeastOnce = "at-least-once"
+  /// At most once delivery, less safe but more performant
+  case atMostOnce = "at-most-once"
+  /// At least once delivery, safe, less performance, quorum queues-specific
+  case atLeastOnce = "at-least-once"
 }

--- a/Sources/Recovery/RecoveryCoordinator.swift
+++ b/Sources/Recovery/RecoveryCoordinator.swift
@@ -5,175 +5,175 @@
 //
 // Copyright (c) 2025-2026 Michael S. Klishin
 
-import Foundation
 import AMQPProtocol
+import Foundation
 import Transport
 
 // MARK: - Recovery Configuration
 
 /// Configuration for automatic connection recovery
 public struct RecoveryConfiguration: Sendable {
-    /// Whether automatic recovery is enabled
-    public var automaticRecovery: Bool
+  /// Whether automatic recovery is enabled
+  public var automaticRecovery: Bool
 
-    /// Initial delay before first recovery attempt (in seconds)
-    public var networkRecoveryInterval: TimeInterval
+  /// Initial delay before first recovery attempt (in seconds)
+  public var networkRecoveryInterval: TimeInterval
 
-    /// Maximum number of recovery attempts (nil for unlimited)
-    public var maxRecoveryAttempts: Int?
+  /// Maximum number of recovery attempts (nil for unlimited)
+  public var maxRecoveryAttempts: Int?
 
-    /// Multiplier for exponential backoff
-    public var backoffMultiplier: Double
+  /// Multiplier for exponential backoff
+  public var backoffMultiplier: Double
 
-    /// Maximum delay between recovery attempts (in seconds)
-    public var maxRecoveryInterval: TimeInterval
+  /// Maximum delay between recovery attempts (in seconds)
+  public var maxRecoveryInterval: TimeInterval
 
-    public init(
-        automaticRecovery: Bool = true,
-        networkRecoveryInterval: TimeInterval = 5.0,
-        maxRecoveryAttempts: Int? = nil,
-        backoffMultiplier: Double = 2.0,
-        maxRecoveryInterval: TimeInterval = 60.0
-    ) {
-        self.automaticRecovery = automaticRecovery
-        self.networkRecoveryInterval = networkRecoveryInterval
-        self.maxRecoveryAttempts = maxRecoveryAttempts
-        self.backoffMultiplier = backoffMultiplier
-        self.maxRecoveryInterval = maxRecoveryInterval
-    }
+  public init(
+    automaticRecovery: Bool = true,
+    networkRecoveryInterval: TimeInterval = 5.0,
+    maxRecoveryAttempts: Int? = nil,
+    backoffMultiplier: Double = 2.0,
+    maxRecoveryInterval: TimeInterval = 60.0
+  ) {
+    self.automaticRecovery = automaticRecovery
+    self.networkRecoveryInterval = networkRecoveryInterval
+    self.maxRecoveryAttempts = maxRecoveryAttempts
+    self.backoffMultiplier = backoffMultiplier
+    self.maxRecoveryInterval = maxRecoveryInterval
+  }
 
-    /// Default configuration with automatic recovery enabled
-    public static let `default` = RecoveryConfiguration()
+  /// Default configuration with automatic recovery enabled
+  public static let `default` = RecoveryConfiguration()
 
-    /// Configuration with automatic recovery disabled
-    public static let noRecovery = RecoveryConfiguration(automaticRecovery: false)
+  /// Configuration with automatic recovery disabled
+  public static let noRecovery = RecoveryConfiguration(automaticRecovery: false)
 }
 
 // MARK: - Recovery State
 
 /// Current state of the recovery process
 public enum RecoveryState: Sendable {
-    case idle
-    case recovering(attempt: Int)
-    case recovered
-    case failed(Error)
+  case idle
+  case recovering(attempt: Int)
+  case recovered
+  case failed(Error)
 }
 
 // MARK: - Recovery Callbacks
 
 /// Callbacks for receiving recovery events
 public struct RecoveryCallbacks: Sendable {
-    public var onRecoveryWillBegin: (@Sendable (Int) async -> Void)?
-    public var onRecoveryDidComplete: (@Sendable () async -> Void)?
-    public var onRecoveryDidFail: (@Sendable (Error) async -> Void)?
-    public var onTopologyRecoveryDidBegin: (@Sendable () async -> Void)?
-    public var onTopologyRecoveryDidComplete: (@Sendable () async -> Void)?
+  public var onRecoveryWillBegin: (@Sendable (Int) async -> Void)?
+  public var onRecoveryDidComplete: (@Sendable () async -> Void)?
+  public var onRecoveryDidFail: (@Sendable (Error) async -> Void)?
+  public var onTopologyRecoveryDidBegin: (@Sendable () async -> Void)?
+  public var onTopologyRecoveryDidComplete: (@Sendable () async -> Void)?
 
-    public init(
-        onRecoveryWillBegin: (@Sendable (Int) async -> Void)? = nil,
-        onRecoveryDidComplete: (@Sendable () async -> Void)? = nil,
-        onRecoveryDidFail: (@Sendable (Error) async -> Void)? = nil,
-        onTopologyRecoveryDidBegin: (@Sendable () async -> Void)? = nil,
-        onTopologyRecoveryDidComplete: (@Sendable () async -> Void)? = nil
-    ) {
-        self.onRecoveryWillBegin = onRecoveryWillBegin
-        self.onRecoveryDidComplete = onRecoveryDidComplete
-        self.onRecoveryDidFail = onRecoveryDidFail
-        self.onTopologyRecoveryDidBegin = onTopologyRecoveryDidBegin
-        self.onTopologyRecoveryDidComplete = onTopologyRecoveryDidComplete
-    }
+  public init(
+    onRecoveryWillBegin: (@Sendable (Int) async -> Void)? = nil,
+    onRecoveryDidComplete: (@Sendable () async -> Void)? = nil,
+    onRecoveryDidFail: (@Sendable (Error) async -> Void)? = nil,
+    onTopologyRecoveryDidBegin: (@Sendable () async -> Void)? = nil,
+    onTopologyRecoveryDidComplete: (@Sendable () async -> Void)? = nil
+  ) {
+    self.onRecoveryWillBegin = onRecoveryWillBegin
+    self.onRecoveryDidComplete = onRecoveryDidComplete
+    self.onRecoveryDidFail = onRecoveryDidFail
+    self.onTopologyRecoveryDidBegin = onTopologyRecoveryDidBegin
+    self.onTopologyRecoveryDidComplete = onTopologyRecoveryDidComplete
+  }
 }
 
 // MARK: - RecoveryCoordinator
 
 /// Coordinates automatic connection recovery
 public actor RecoveryCoordinator {
-    private let configuration: RecoveryConfiguration
-    private let topology: TopologyRegistry
-    private let callbacks: RecoveryCallbacks
-    private var state: RecoveryState = .idle
-    private var recoveryTask: Task<Void, Never>?
+  private let configuration: RecoveryConfiguration
+  private let topology: TopologyRegistry
+  private let callbacks: RecoveryCallbacks
+  private var state: RecoveryState = .idle
+  private var recoveryTask: Task<Void, Never>?
 
-    public init(
-        configuration: RecoveryConfiguration = .default,
-        topology: TopologyRegistry,
-        callbacks: RecoveryCallbacks = RecoveryCallbacks()
-    ) {
-        self.configuration = configuration
-        self.topology = topology
-        self.callbacks = callbacks
-    }
+  public init(
+    configuration: RecoveryConfiguration = .default,
+    topology: TopologyRegistry,
+    callbacks: RecoveryCallbacks = RecoveryCallbacks()
+  ) {
+    self.configuration = configuration
+    self.topology = topology
+    self.callbacks = callbacks
+  }
 
-    /// Current recovery state
-    public var currentState: RecoveryState {
-        state
-    }
+  /// Current recovery state
+  public var currentState: RecoveryState {
+    state
+  }
 
-    /// Begin recovery process
-    public func beginRecovery(
-        reconnect: @escaping () async throws -> Void,
-        redeclare: @escaping (TopologyRegistry) async throws -> Void
-    ) async {
-        guard configuration.automaticRecovery else { return }
-        guard case .idle = state else { return }
+  /// Begin recovery process
+  public func beginRecovery(
+    reconnect: @escaping () async throws -> Void,
+    redeclare: @escaping (TopologyRegistry) async throws -> Void
+  ) async {
+    guard configuration.automaticRecovery else { return }
+    guard case .idle = state else { return }
 
-        state = .recovering(attempt: 1)
+    state = .recovering(attempt: 1)
 
-        recoveryTask = Task {
-            var attempt = 1
-            var currentInterval = configuration.networkRecoveryInterval
+    recoveryTask = Task {
+      var attempt = 1
+      var currentInterval = configuration.networkRecoveryInterval
 
-            while !Task.isCancelled {
-                if let maxAttempts = configuration.maxRecoveryAttempts, attempt > maxAttempts {
-                    let error = ConnectionError.protocolError("Max recovery attempts exceeded")
-                    state = .failed(error)
-                    await callbacks.onRecoveryDidFail?(error)
-                    return
-                }
-
-                await callbacks.onRecoveryWillBegin?(attempt)
-                state = .recovering(attempt: attempt)
-
-                do {
-                    try await Task.sleep(nanoseconds: UInt64(currentInterval * 1_000_000_000))
-                } catch {
-                    return
-                }
-
-                do {
-                    try await reconnect()
-
-                    await callbacks.onTopologyRecoveryDidBegin?()
-                    try await redeclare(topology)
-                    await callbacks.onTopologyRecoveryDidComplete?()
-
-                    state = .recovered
-                    await callbacks.onRecoveryDidComplete?()
-                    return
-
-                } catch {
-                    attempt += 1
-                    currentInterval = min(
-                        currentInterval * configuration.backoffMultiplier,
-                        configuration.maxRecoveryInterval
-                    )
-                }
-            }
+      while !Task.isCancelled {
+        if let maxAttempts = configuration.maxRecoveryAttempts, attempt > maxAttempts {
+          let error = ConnectionError.protocolError("Max recovery attempts exceeded")
+          state = .failed(error)
+          await callbacks.onRecoveryDidFail?(error)
+          return
         }
-    }
 
-    /// Cancel ongoing recovery
-    public func cancelRecovery() {
-        recoveryTask?.cancel()
-        recoveryTask = nil
-        state = .idle
-    }
+        await callbacks.onRecoveryWillBegin?(attempt)
+        state = .recovering(attempt: attempt)
 
-    /// Reset coordinator state
-    public func reset() {
-        cancelRecovery()
-        state = .idle
+        do {
+          try await Task.sleep(nanoseconds: UInt64(currentInterval * 1_000_000_000))
+        } catch {
+          return
+        }
+
+        do {
+          try await reconnect()
+
+          await callbacks.onTopologyRecoveryDidBegin?()
+          try await redeclare(topology)
+          await callbacks.onTopologyRecoveryDidComplete?()
+
+          state = .recovered
+          await callbacks.onRecoveryDidComplete?()
+          return
+
+        } catch {
+          attempt += 1
+          currentInterval = min(
+            currentInterval * configuration.backoffMultiplier,
+            configuration.maxRecoveryInterval
+          )
+        }
+      }
     }
+  }
+
+  /// Cancel ongoing recovery
+  public func cancelRecovery() {
+    recoveryTask?.cancel()
+    recoveryTask = nil
+    state = .idle
+  }
+
+  /// Reset coordinator state
+  public func reset() {
+    cancelRecovery()
+    state = .idle
+  }
 }
 
 // Note: Topology redeclaration is handled by Connection during recovery.

--- a/Sources/Recovery/TopologyRegistry.swift
+++ b/Sources/Recovery/TopologyRegistry.swift
@@ -5,249 +5,250 @@
 //
 // Copyright (c) 2025-2026 Michael S. Klishin
 
-import Foundation
 import AMQPProtocol
+import Foundation
 
 // MARK: - Recorded Entities
 
 public struct RecordedExchange: Sendable, Equatable, Hashable {
-    public let name: String
-    public let type: String
-    public let durable: Bool
-    public let autoDelete: Bool
-    public let `internal`: Bool
-    public let arguments: Table
+  public let name: String
+  public let type: String
+  public let durable: Bool
+  public let autoDelete: Bool
+  public let `internal`: Bool
+  public let arguments: Table
 
-    public init(
-        name: String,
-        type: String,
-        durable: Bool,
-        autoDelete: Bool,
-        internal: Bool,
-        arguments: Table
-    ) {
-        self.name = name
-        self.type = type
-        self.durable = durable
-        self.autoDelete = autoDelete
-        self.internal = `internal`
-        self.arguments = arguments
-    }
+  public init(
+    name: String,
+    type: String,
+    durable: Bool,
+    autoDelete: Bool,
+    internal: Bool,
+    arguments: Table
+  ) {
+    self.name = name
+    self.type = type
+    self.durable = durable
+    self.autoDelete = autoDelete
+    self.internal = `internal`
+    self.arguments = arguments
+  }
 }
 
 public struct RecordedQueue: Sendable, Equatable, Hashable {
-    public let name: String
-    public let durable: Bool
-    public let exclusive: Bool
-    public let autoDelete: Bool
-    public let arguments: Table
-    public var serverNamed: Bool
+  public let name: String
+  public let durable: Bool
+  public let exclusive: Bool
+  public let autoDelete: Bool
+  public let arguments: Table
+  public var serverNamed: Bool
 
-    public init(
-        name: String,
-        durable: Bool,
-        exclusive: Bool,
-        autoDelete: Bool,
-        arguments: Table,
-        serverNamed: Bool = false
-    ) {
-        self.name = name
-        self.durable = durable
-        self.exclusive = exclusive
-        self.autoDelete = autoDelete
-        self.arguments = arguments
-        self.serverNamed = serverNamed
-    }
+  public init(
+    name: String,
+    durable: Bool,
+    exclusive: Bool,
+    autoDelete: Bool,
+    arguments: Table,
+    serverNamed: Bool = false
+  ) {
+    self.name = name
+    self.durable = durable
+    self.exclusive = exclusive
+    self.autoDelete = autoDelete
+    self.arguments = arguments
+    self.serverNamed = serverNamed
+  }
 }
 
 public struct RecordedQueueBinding: Sendable, Equatable, Hashable {
-    public let queue: String
-    public let exchange: String
-    public let routingKey: String
-    public let arguments: Table
+  public let queue: String
+  public let exchange: String
+  public let routingKey: String
+  public let arguments: Table
 
-    public init(queue: String, exchange: String, routingKey: String, arguments: Table) {
-        self.queue = queue
-        self.exchange = exchange
-        self.routingKey = routingKey
-        self.arguments = arguments
-    }
+  public init(queue: String, exchange: String, routingKey: String, arguments: Table) {
+    self.queue = queue
+    self.exchange = exchange
+    self.routingKey = routingKey
+    self.arguments = arguments
+  }
 }
 
 public struct RecordedExchangeBinding: Sendable, Equatable, Hashable {
-    public let destination: String
-    public let source: String
-    public let routingKey: String
-    public let arguments: Table
+  public let destination: String
+  public let source: String
+  public let routingKey: String
+  public let arguments: Table
 
-    public init(destination: String, source: String, routingKey: String, arguments: Table) {
-        self.destination = destination
-        self.source = source
-        self.routingKey = routingKey
-        self.arguments = arguments
-    }
+  public init(destination: String, source: String, routingKey: String, arguments: Table) {
+    self.destination = destination
+    self.source = source
+    self.routingKey = routingKey
+    self.arguments = arguments
+  }
 }
 
 public struct RecordedConsumer: Sendable, Equatable, Hashable {
-    public let consumerTag: String
-    public let queue: String
-    public let acknowledgementMode: ConsumerAcknowledgementMode
-    public let exclusive: Bool
-    public let arguments: Table
+  public let consumerTag: String
+  public let queue: String
+  public let acknowledgementMode: ConsumerAcknowledgementMode
+  public let exclusive: Bool
+  public let arguments: Table
 
-    public init(
-        consumerTag: String,
-        queue: String,
-        acknowledgementMode: ConsumerAcknowledgementMode,
-        exclusive: Bool,
-        arguments: Table
-    ) {
-        self.consumerTag = consumerTag
-        self.queue = queue
-        self.acknowledgementMode = acknowledgementMode
-        self.exclusive = exclusive
-        self.arguments = arguments
-    }
+  public init(
+    consumerTag: String,
+    queue: String,
+    acknowledgementMode: ConsumerAcknowledgementMode,
+    exclusive: Bool,
+    arguments: Table
+  ) {
+    self.consumerTag = consumerTag
+    self.queue = queue
+    self.acknowledgementMode = acknowledgementMode
+    self.exclusive = exclusive
+    self.arguments = arguments
+  }
 }
 
 // MARK: - TopologyRegistry
 
 public actor TopologyRegistry {
-    private var exchanges: [String: RecordedExchange] = [:]
-    private var queues: [String: RecordedQueue] = [:]
-    private var queueBindings: Set<RecordedQueueBinding> = []
-    private var exchangeBindings: Set<RecordedExchangeBinding> = []
-    private var consumers: [String: RecordedConsumer] = [:]
+  private var exchanges: [String: RecordedExchange] = [:]
+  private var queues: [String: RecordedQueue] = [:]
+  private var queueBindings: Set<RecordedQueueBinding> = []
+  private var exchangeBindings: Set<RecordedExchangeBinding> = []
+  private var consumers: [String: RecordedConsumer] = [:]
 
-    public init() {}
+  public init() {}
 
-    // MARK: - Exchanges
+  // MARK: - Exchanges
 
-    public func recordExchange(_ exchange: RecordedExchange) {
-        exchanges[exchange.name] = exchange
+  public func recordExchange(_ exchange: RecordedExchange) {
+    exchanges[exchange.name] = exchange
+  }
+
+  public func deleteExchange(named name: String) {
+    exchanges.removeValue(forKey: name)
+    // Remove bindings involving this exchange
+    queueBindings = queueBindings.filter { $0.exchange != name }
+    exchangeBindings = exchangeBindings.filter {
+      $0.source != name && $0.destination != name
+    }
+  }
+
+  public func allExchanges() -> [RecordedExchange] {
+    Array(exchanges.values)
+  }
+
+  // MARK: - Queues
+
+  public func recordQueue(_ queue: RecordedQueue) {
+    queues[queue.name] = queue
+  }
+
+  public func deleteQueue(named name: String) {
+    queues.removeValue(forKey: name)
+    // Remove bindings involving this queue
+    queueBindings = queueBindings.filter { $0.queue != name }
+    // Remove consumers for this queue
+    consumers = consumers.filter { $0.value.queue != name }
+  }
+
+  public func allQueues() -> [RecordedQueue] {
+    Array(queues.values)
+  }
+
+  /// Update queue name after server-named queue is redeclared
+  public func updateQueueName(from oldName: String, to newName: String) {
+    guard var queue = queues.removeValue(forKey: oldName) else { return }
+    queue = RecordedQueue(
+      name: newName,
+      durable: queue.durable,
+      exclusive: queue.exclusive,
+      autoDelete: queue.autoDelete,
+      arguments: queue.arguments,
+      serverNamed: queue.serverNamed
+    )
+    queues[newName] = queue
+
+    // Update bindings
+    let oldBindings = queueBindings.filter { $0.queue == oldName }
+    for binding in oldBindings {
+      queueBindings.remove(binding)
+      queueBindings.insert(
+        RecordedQueueBinding(
+          queue: newName,
+          exchange: binding.exchange,
+          routingKey: binding.routingKey,
+          arguments: binding.arguments
+        ))
     }
 
-    public func deleteExchange(named name: String) {
-        exchanges.removeValue(forKey: name)
-        // Remove bindings involving this exchange
-        queueBindings = queueBindings.filter { $0.exchange != name }
-        exchangeBindings = exchangeBindings.filter {
-            $0.source != name && $0.destination != name
-        }
+    // Update consumers
+    for (tag, consumer) in consumers where consumer.queue == oldName {
+      consumers[tag] = RecordedConsumer(
+        consumerTag: consumer.consumerTag,
+        queue: newName,
+        acknowledgementMode: consumer.acknowledgementMode,
+        exclusive: consumer.exclusive,
+        arguments: consumer.arguments
+      )
     }
+  }
 
-    public func allExchanges() -> [RecordedExchange] {
-        Array(exchanges.values)
-    }
+  // MARK: - Queue Bindings
 
-    // MARK: - Queues
+  public func recordQueueBinding(_ binding: RecordedQueueBinding) {
+    queueBindings.insert(binding)
+  }
 
-    public func recordQueue(_ queue: RecordedQueue) {
-        queues[queue.name] = queue
-    }
+  public func deleteQueueBinding(_ binding: RecordedQueueBinding) {
+    queueBindings.remove(binding)
+  }
 
-    public func deleteQueue(named name: String) {
-        queues.removeValue(forKey: name)
-        // Remove bindings involving this queue
-        queueBindings = queueBindings.filter { $0.queue != name }
-        // Remove consumers for this queue
-        consumers = consumers.filter { $0.value.queue != name }
-    }
+  public func allQueueBindings() -> [RecordedQueueBinding] {
+    Array(queueBindings)
+  }
 
-    public func allQueues() -> [RecordedQueue] {
-        Array(queues.values)
-    }
+  // MARK: - Exchange Bindings
 
-    /// Update queue name after server-named queue is redeclared
-    public func updateQueueName(from oldName: String, to newName: String) {
-        guard var queue = queues.removeValue(forKey: oldName) else { return }
-        queue = RecordedQueue(
-            name: newName,
-            durable: queue.durable,
-            exclusive: queue.exclusive,
-            autoDelete: queue.autoDelete,
-            arguments: queue.arguments,
-            serverNamed: queue.serverNamed
-        )
-        queues[newName] = queue
+  public func recordExchangeBinding(_ binding: RecordedExchangeBinding) {
+    exchangeBindings.insert(binding)
+  }
 
-        // Update bindings
-        let oldBindings = queueBindings.filter { $0.queue == oldName }
-        for binding in oldBindings {
-            queueBindings.remove(binding)
-            queueBindings.insert(RecordedQueueBinding(
-                queue: newName,
-                exchange: binding.exchange,
-                routingKey: binding.routingKey,
-                arguments: binding.arguments
-            ))
-        }
+  public func deleteExchangeBinding(_ binding: RecordedExchangeBinding) {
+    exchangeBindings.remove(binding)
+  }
 
-        // Update consumers
-        for (tag, consumer) in consumers where consumer.queue == oldName {
-            consumers[tag] = RecordedConsumer(
-                consumerTag: consumer.consumerTag,
-                queue: newName,
-                acknowledgementMode: consumer.acknowledgementMode,
-                exclusive: consumer.exclusive,
-                arguments: consumer.arguments
-            )
-        }
-    }
+  public func allExchangeBindings() -> [RecordedExchangeBinding] {
+    Array(exchangeBindings)
+  }
 
-    // MARK: - Queue Bindings
+  // MARK: - Consumers
 
-    public func recordQueueBinding(_ binding: RecordedQueueBinding) {
-        queueBindings.insert(binding)
-    }
+  public func recordConsumer(_ consumer: RecordedConsumer) {
+    consumers[consumer.consumerTag] = consumer
+  }
 
-    public func deleteQueueBinding(_ binding: RecordedQueueBinding) {
-        queueBindings.remove(binding)
-    }
+  public func deleteConsumer(tag: String) {
+    consumers.removeValue(forKey: tag)
+  }
 
-    public func allQueueBindings() -> [RecordedQueueBinding] {
-        Array(queueBindings)
-    }
+  public func allConsumers() -> [RecordedConsumer] {
+    Array(consumers.values)
+  }
 
-    // MARK: - Exchange Bindings
+  public func consumer(forTag tag: String) -> RecordedConsumer? {
+    consumers[tag]
+  }
 
-    public func recordExchangeBinding(_ binding: RecordedExchangeBinding) {
-        exchangeBindings.insert(binding)
-    }
+  // MARK: - Clear
 
-    public func deleteExchangeBinding(_ binding: RecordedExchangeBinding) {
-        exchangeBindings.remove(binding)
-    }
-
-    public func allExchangeBindings() -> [RecordedExchangeBinding] {
-        Array(exchangeBindings)
-    }
-
-    // MARK: - Consumers
-
-    public func recordConsumer(_ consumer: RecordedConsumer) {
-        consumers[consumer.consumerTag] = consumer
-    }
-
-    public func deleteConsumer(tag: String) {
-        consumers.removeValue(forKey: tag)
-    }
-
-    public func allConsumers() -> [RecordedConsumer] {
-        Array(consumers.values)
-    }
-
-    public func consumer(forTag tag: String) -> RecordedConsumer? {
-        consumers[tag]
-    }
-
-    // MARK: - Clear
-
-    public func clear() {
-        exchanges.removeAll()
-        queues.removeAll()
-        queueBindings.removeAll()
-        exchangeBindings.removeAll()
-        consumers.removeAll()
-    }
+  public func clear() {
+    exchanges.removeAll()
+    queues.removeAll()
+    queueBindings.removeAll()
+    exchangeBindings.removeAll()
+    consumers.removeAll()
+  }
 }

--- a/Sources/Transport/AMQPTransport.swift
+++ b/Sources/Transport/AMQPTransport.swift
@@ -32,36 +32,29 @@ private final class IteratorBox<Element>: @unchecked Sendable {
   }
 }
 
-/// Encoder added after handshake to avoid type conflicts with raw ByteBuffer writes
-private struct PlainChannelInitializer: @unchecked Sendable {
+private struct PipelineInitializer: @unchecked Sendable {
   let frameMax: UInt32
-  let continuation: AsyncStream<Frame>.Continuation
-
-  func initialize(_ channel: NIO.Channel) -> EventLoopFuture<Void> {
-    channel.pipeline.addHandler(ByteToMessageHandler(AMQPFrameDecoder(maxFrameSize: frameMax)))
-      .flatMap {
-        channel.pipeline.addHandler(FrameForwardingHandler(continuation: self.continuation))
-      }
-  }
-}
-
-private struct TLSChannelInitializer: @unchecked Sendable {
-  let frameMax: UInt32
-  let sslContext: NIOSSLContext
+  let sslContext: NIOSSLContext?
   let hostname: String
   let continuation: AsyncStream<Frame>.Continuation
 
   func initialize(_ channel: NIO.Channel) -> EventLoopFuture<Void> {
-    do {
-      let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: hostname)
-      return channel.pipeline.addHandler(sslHandler).flatMap {
-        channel.pipeline.addHandler(
-          ByteToMessageHandler(AMQPFrameDecoder(maxFrameSize: self.frameMax)))
-      }.flatMap {
-        channel.pipeline.addHandler(FrameForwardingHandler(continuation: self.continuation))
+    var future = channel.eventLoop.makeSucceededVoidFuture()
+
+    if let sslContext = sslContext {
+      do {
+        let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: hostname)
+        future = channel.pipeline.addHandler(sslHandler)
+      } catch {
+        return channel.eventLoop.makeFailedFuture(error)
       }
-    } catch {
-      return channel.eventLoop.makeFailedFuture(error)
+    }
+
+    return future.flatMap {
+      channel.pipeline.addHandler(
+        ByteToMessageHandler(AMQPFrameDecoder(maxFrameSize: self.frameMax)))
+    }.flatMap {
+      channel.pipeline.addHandler(FrameForwardingHandler(continuation: self.continuation))
     }
   }
 }
@@ -134,95 +127,35 @@ public actor AMQPTransport {
     configuration: ConnectionConfiguration,
     continuation: AsyncStream<Frame>.Continuation
   ) async throws -> Channel {
-    let frameMax = configuration.frameMax
-    let host = configuration.host
-    let port = configuration.port
+    let sslContext: NIOSSLContext? =
+      if let tlsConfig = configuration.tls {
+        try NIOSSLContext(configuration: tlsConfig.toNIOSSLConfiguration())
+      } else {
+        nil
+      }
 
-    if let tlsConfig = configuration.tls {
-      return try await createTLSChannel(
-        host: host,
-        port: port,
-        frameMax: frameMax,
-        tlsConfig: tlsConfig,
-        timeout: configuration.connectionTimeout,
-        enableTCPNoDelay: configuration.enableTCPNoDelay,
-        enableTCPKeepAlive: configuration.enableTCPKeepAlive,
-        continuation: continuation
-      )
-    } else {
-      return try await createPlainChannel(
-        host: host,
-        port: port,
-        frameMax: frameMax,
-        timeout: configuration.connectionTimeout,
-        enableTCPNoDelay: configuration.enableTCPNoDelay,
-        enableTCPKeepAlive: configuration.enableTCPKeepAlive,
-        continuation: continuation
-      )
-    }
-  }
-
-  private func createPlainChannel(
-    host: String,
-    port: Int,
-    frameMax: UInt32,
-    timeout: TimeAmount,
-    enableTCPNoDelay: Bool,
-    enableTCPKeepAlive: Bool,
-    continuation: AsyncStream<Frame>.Continuation
-  ) async throws -> Channel {
-    let promise = eventLoopGroup.next().makePromise(of: Channel.self)
-    let initializer = PlainChannelInitializer(frameMax: frameMax, continuation: continuation)
-
-    var bootstrap = ClientBootstrap(group: eventLoopGroup)
-      .channelOption(.socketOption(.so_reuseaddr), value: 1)
-      .connectTimeout(timeout)
-      .channelInitializer(initializer.initialize)
-
-    if enableTCPKeepAlive {
-      bootstrap = bootstrap.channelOption(.socketOption(.so_keepalive), value: 1)
-    }
-    if enableTCPNoDelay {
-      bootstrap = bootstrap.channelOption(.socketOption(.tcp_nodelay), value: 1)
-    }
-
-    bootstrap.connect(host: host, port: port).cascade(to: promise)
-
-    return try await promise.futureResult.get()
-  }
-
-  private func createTLSChannel(
-    host: String,
-    port: Int,
-    frameMax: UInt32,
-    tlsConfig: TLSConfiguration,
-    timeout: TimeAmount,
-    enableTCPNoDelay: Bool,
-    enableTCPKeepAlive: Bool,
-    continuation: AsyncStream<Frame>.Continuation
-  ) async throws -> Channel {
-    let sslContext = try NIOSSLContext(configuration: tlsConfig.toNIOSSLConfiguration())
-    let promise = eventLoopGroup.next().makePromise(of: Channel.self)
-    let initializer = TLSChannelInitializer(
-      frameMax: frameMax,
+    let initializer = PipelineInitializer(
+      frameMax: configuration.frameMax,
       sslContext: sslContext,
-      hostname: host,
+      hostname: configuration.host,
       continuation: continuation
     )
 
+    let promise = eventLoopGroup.next().makePromise(of: Channel.self)
+
     var bootstrap = ClientBootstrap(group: eventLoopGroup)
       .channelOption(.socketOption(.so_reuseaddr), value: 1)
-      .connectTimeout(timeout)
+      .connectTimeout(configuration.connectionTimeout)
       .channelInitializer(initializer.initialize)
 
-    if enableTCPKeepAlive {
+    if configuration.enableTCPKeepAlive {
       bootstrap = bootstrap.channelOption(.socketOption(.so_keepalive), value: 1)
     }
-    if enableTCPNoDelay {
+    if configuration.enableTCPNoDelay {
       bootstrap = bootstrap.channelOption(.socketOption(.tcp_nodelay), value: 1)
     }
 
-    bootstrap.connect(host: host, port: port).cascade(to: promise)
+    bootstrap.connect(host: configuration.host, port: configuration.port).cascade(to: promise)
 
     return try await promise.futureResult.get()
   }
@@ -338,7 +271,10 @@ public actor AMQPTransport {
       throw ConnectionError.notConnected
     }
     let encoder = AMQPFrameEncoder(maxFrameSize: frameMax)
-    try await channel.pipeline.addHandler(encoder, position: .first).get()
+    // Must sit before the forwarding handler so outbound frames are
+    // encoded to ByteBuffer before reaching the TLS handler.
+    let anchor = try await channel.pipeline.handler(type: FrameForwardingHandler.self).get()
+    try await channel.pipeline.addHandler(encoder, position: .before(anchor)).get()
   }
 
   private func setupHeartbeat(interval: UInt16) async throws {
@@ -349,7 +285,10 @@ public actor AMQPTransport {
         await self?.handleHeartbeatTimeout()
       }
     }
-    try await channel.pipeline.addHandler(handler, name: "heartbeat").get()
+    // Must sit before the forwarding handler to see inbound frames.
+    let anchor = try await channel.pipeline.handler(type: FrameForwardingHandler.self).get()
+    try await channel.pipeline.addHandler(handler, name: "heartbeat", position: .before(anchor))
+      .get()
   }
 
   private func handleHeartbeatTimeout() {

--- a/Sources/Transport/FrameHandler.swift
+++ b/Sources/Transport/FrameHandler.swift
@@ -5,391 +5,405 @@
 //
 // Copyright (c) 2025-2026 Michael S. Klishin
 
+import AMQPProtocol
 import Foundation
 import NIO
 import NIOFoundationCompat
-import AMQPProtocol
 
 final class AMQPFrameDecoder: ByteToMessageDecoder, RemovableChannelHandler, @unchecked Sendable {
-    typealias InboundIn = ByteBuffer
-    typealias InboundOut = Frame
+  typealias InboundIn = ByteBuffer
+  typealias InboundOut = Frame
 
-    private let maxFrameSize: UInt32
+  private let maxFrameSize: UInt32
 
-    init(maxFrameSize: UInt32 = FrameDefaults.maxSize) {
-        self.maxFrameSize = maxFrameSize
-    }
+  init(maxFrameSize: UInt32 = FrameDefaults.maxSize) {
+    self.maxFrameSize = maxFrameSize
+  }
 
-    func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
-        while buffer.readableBytes >= FrameDefaults.headerSize + 1 {
-            guard let frame = try decodeFrame(from: &buffer) else {
-                return .needMoreData
-            }
-            context.fireChannelRead(wrapInboundOut(frame))
-        }
+  func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
+    while buffer.readableBytes >= FrameDefaults.headerSize + 1 {
+      guard let frame = try decodeFrame(from: &buffer) else {
         return .needMoreData
+      }
+      context.fireChannelRead(wrapInboundOut(frame))
+    }
+    return .needMoreData
+  }
+
+  private func decodeFrame(from buffer: inout ByteBuffer) throws -> Frame? {
+    let readerIndex = buffer.readerIndex
+
+    guard let frameType = buffer.readInteger(as: UInt8.self),
+      let channelID = buffer.readInteger(endianness: .big, as: UInt16.self),
+      let payloadSize = buffer.readInteger(endianness: .big, as: UInt32.self)
+    else {
+      buffer.moveReaderIndex(to: readerIndex)
+      return nil
     }
 
-    private func decodeFrame(from buffer: inout ByteBuffer) throws -> Frame? {
-        let readerIndex = buffer.readerIndex
-
-        guard let frameType = buffer.readInteger(as: UInt8.self),
-              let channelID = buffer.readInteger(endianness: .big, as: UInt16.self),
-              let payloadSize = buffer.readInteger(endianness: .big, as: UInt32.self) else {
-            buffer.moveReaderIndex(to: readerIndex)
-            return nil
-        }
-
-        // Validate payload size against max frame size
-        let maxPayload = maxFrameSize - UInt32(FrameDefaults.headerSize) - 1
-        guard payloadSize <= maxPayload else {
-            throw WireFormatError.frameTooLarge(size: payloadSize, maxSize: maxFrameSize)
-        }
-
-        guard buffer.readableBytes >= Int(payloadSize) + 1 else {
-            buffer.moveReaderIndex(to: readerIndex)
-            return nil
-        }
-
-        guard let payload = buffer.readSlice(length: Int(payloadSize)),
-              let frameEnd = buffer.readInteger(as: UInt8.self) else {
-            buffer.moveReaderIndex(to: readerIndex)
-            return nil
-        }
-
-        guard frameEnd == AMQPProtocol.frameEnd else {
-            throw WireFormatError.invalidFrameEnd(expected: AMQPProtocol.frameEnd, actual: frameEnd)
-        }
-
-        return try parseFrame(type: frameType, channelID: channelID, payload: payload)
+    // Validate payload size against max frame size
+    let maxPayload = maxFrameSize - UInt32(FrameDefaults.headerSize) - 1
+    guard payloadSize <= maxPayload else {
+      throw WireFormatError.frameTooLarge(size: payloadSize, maxSize: maxFrameSize)
     }
 
-    private func parseFrame(type: UInt8, channelID: UInt16, payload: ByteBuffer) throws -> Frame {
-        guard let frameType = FrameType(rawValue: type) else {
-            throw WireFormatError.unknownFrameType(type)
-        }
-
-        switch frameType {
-        case .method:
-            let data = Data(buffer: payload)
-            let method = try FrameCodec().decodeMethod(from: data)
-            return .method(channelID: channelID, method: method)
-
-        case .header:
-            var buf = payload
-            guard let classID = buf.readInteger(endianness: .big, as: UInt16.self),
-                  let _ = buf.readInteger(endianness: .big, as: UInt16.self),  // weight (reserved)
-                  let bodySize = buf.readInteger(endianness: .big, as: UInt64.self) else {
-                throw WireFormatError.insufficientData(needed: 12, available: payload.readableBytes)
-            }
-            let propsData = Data(buffer: buf)
-            var decoder = propsData.wireDecoder()
-            let properties = try BasicProperties.decode(from: &decoder)
-            return .header(channelID: channelID, classID: classID, bodySize: bodySize, properties: properties)
-
-        case .body:
-            return .body(channelID: channelID, payload: Data(buffer: payload))
-
-        case .heartbeat:
-            return .heartbeat
-        }
+    guard buffer.readableBytes >= Int(payloadSize) + 1 else {
+      buffer.moveReaderIndex(to: readerIndex)
+      return nil
     }
 
-    func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
-        try decode(context: context, buffer: &buffer)
+    guard let payload = buffer.readSlice(length: Int(payloadSize)),
+      let frameEnd = buffer.readInteger(as: UInt8.self)
+    else {
+      buffer.moveReaderIndex(to: readerIndex)
+      return nil
     }
+
+    guard frameEnd == AMQPProtocol.frameEnd else {
+      throw WireFormatError.invalidFrameEnd(expected: AMQPProtocol.frameEnd, actual: frameEnd)
+    }
+
+    return try parseFrame(type: frameType, channelID: channelID, payload: payload)
+  }
+
+  private func parseFrame(type: UInt8, channelID: UInt16, payload: ByteBuffer) throws -> Frame {
+    guard let frameType = FrameType(rawValue: type) else {
+      throw WireFormatError.unknownFrameType(type)
+    }
+
+    switch frameType {
+    case .method:
+      let data = Data(buffer: payload)
+      let method = try FrameCodec().decodeMethod(from: data)
+      return .method(channelID: channelID, method: method)
+
+    case .header:
+      var buf = payload
+      guard let classID = buf.readInteger(endianness: .big, as: UInt16.self),
+        buf.readInteger(endianness: .big, as: UInt16.self) != nil,  // weight (reserved)
+        let bodySize = buf.readInteger(endianness: .big, as: UInt64.self)
+      else {
+        throw WireFormatError.insufficientData(needed: 12, available: payload.readableBytes)
+      }
+      let propsData = Data(buffer: buf)
+      var decoder = propsData.wireDecoder()
+      let properties = try BasicProperties.decode(from: &decoder)
+      return .header(
+        channelID: channelID, classID: classID, bodySize: bodySize, properties: properties)
+
+    case .body:
+      return .body(channelID: channelID, payload: Data(buffer: payload))
+
+    case .heartbeat:
+      return .heartbeat
+    }
+  }
+
+  func decodeLast(context: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws
+    -> DecodingState
+  {
+    try decode(context: context, buffer: &buffer)
+  }
 }
 
 // MARK: - Frame Encoder
 
 /// Encodes AMQP frames directly to ByteBuffer for zero-copy performance
 final class AMQPFrameEncoder: ChannelOutboundHandler, RemovableChannelHandler, @unchecked Sendable {
-    typealias OutboundIn = Frame
-    typealias OutboundOut = ByteBuffer
+  typealias OutboundIn = Frame
+  typealias OutboundOut = ByteBuffer
 
-    private let maxFrameSize: UInt32
-    private let codec: FrameCodec
+  private let maxFrameSize: UInt32
+  private let codec: FrameCodec
 
-    init(maxFrameSize: UInt32 = FrameDefaults.maxSize) {
-        self.maxFrameSize = maxFrameSize
-        self.codec = FrameCodec(maxFrameSize: maxFrameSize)
+  init(maxFrameSize: UInt32 = FrameDefaults.maxSize) {
+    self.maxFrameSize = maxFrameSize
+    self.codec = FrameCodec(maxFrameSize: maxFrameSize)
+  }
+
+  func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    let frame = unwrapOutboundIn(data)
+    do {
+      var buffer = context.channel.allocator.buffer(capacity: estimateFrameSize(frame))
+      try encodeFrame(frame, to: &buffer)
+      context.write(wrapOutboundOut(buffer), promise: promise)
+    } catch {
+      promise?.fail(error)
     }
+  }
 
-    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        let frame = unwrapOutboundIn(data)
-        do {
-            var buffer = context.channel.allocator.buffer(capacity: estimateFrameSize(frame))
-            try encodeFrame(frame, to: &buffer)
-            context.write(wrapOutboundOut(buffer), promise: promise)
-        } catch {
-            promise?.fail(error)
-        }
+  private func estimateFrameSize(_ frame: Frame) -> Int {
+    switch frame {
+    case .body(_, let payload):
+      return 8 + payload.count + 1
+    case .heartbeat:
+      return 8
+    case .header:
+      return 128  // Properties vary, reasonable estimate
+    case .method:
+      return 256  // Method args vary, reasonable estimate
     }
+  }
 
-    private func estimateFrameSize(_ frame: Frame) -> Int {
-        switch frame {
-        case .body(_, let payload):
-            return 8 + payload.count + 1
-        case .heartbeat:
-            return 8
-        case .header:
-            return 128  // Properties vary, reasonable estimate
-        case .method:
-            return 256  // Method args vary, reasonable estimate
-        }
+  private func encodeFrame(_ frame: Frame, to buffer: inout ByteBuffer) throws {
+    switch frame {
+    case .body(let channelID, let payload):
+      // Fast path: encode body frame directly
+      buffer.writeInteger(FrameType.body.rawValue)
+      buffer.writeInteger(channelID, endianness: .big)
+      buffer.writeInteger(UInt32(payload.count), endianness: .big)
+      buffer.writeContiguousBytes(payload)
+      buffer.writeInteger(frameEnd)
+
+    case .heartbeat:
+      buffer.writeInteger(FrameType.heartbeat.rawValue)
+      buffer.writeInteger(UInt16(0), endianness: .big)
+      buffer.writeInteger(UInt32(0), endianness: .big)
+      buffer.writeInteger(frameEnd)
+
+    case .method(let channelID, let method):
+      if case .basicPublish(let publish) = method {
+        // Hot path: encode BasicPublish directly
+        encodeBasicPublish(channelID: channelID, publish: publish, to: &buffer)
+      } else {
+        let encoded = try codec.encode(frame)
+        buffer.writeContiguousBytes(encoded)
+      }
+
+    case .header(let channelID, let classID, let bodySize, let properties):
+      try encodeHeader(
+        channelID: channelID, classID: classID, bodySize: bodySize, properties: properties,
+        to: &buffer)
     }
+  }
 
-    private func encodeFrame(_ frame: Frame, to buffer: inout ByteBuffer) throws {
-        switch frame {
-        case .body(let channelID, let payload):
-            // Fast path: encode body frame directly
-            buffer.writeInteger(FrameType.body.rawValue)
-            buffer.writeInteger(channelID, endianness: .big)
-            buffer.writeInteger(UInt32(payload.count), endianness: .big)
-            buffer.writeContiguousBytes(payload)
-            buffer.writeInteger(frameEnd)
+  private func encodeHeader(
+    channelID: UInt16, classID: UInt16, bodySize: UInt64, properties: BasicProperties,
+    to buffer: inout ByteBuffer
+  ) throws {
+    // Encode properties to temp buffer to get size
+    var propsEncoder = WireEncoder()
+    try properties.encode(to: &propsEncoder)
+    let propsData = propsEncoder.encodedData
 
-        case .heartbeat:
-            buffer.writeInteger(FrameType.heartbeat.rawValue)
-            buffer.writeInteger(UInt16(0), endianness: .big)
-            buffer.writeInteger(UInt32(0), endianness: .big)
-            buffer.writeInteger(frameEnd)
+    // Payload: classID(2) + weight(2) + bodySize(8) + properties(variable)
+    let payloadSize = 2 + 2 + 8 + propsData.count
 
-        case .method(let channelID, let method):
-            if case .basicPublish(let publish) = method {
-                // Hot path: encode BasicPublish directly
-                encodeBasicPublish(channelID: channelID, publish: publish, to: &buffer)
-            } else {
-                let encoded = try codec.encode(frame)
-                buffer.writeContiguousBytes(encoded)
-            }
+    buffer.writeInteger(FrameType.header.rawValue)
+    buffer.writeInteger(channelID, endianness: .big)
+    buffer.writeInteger(UInt32(payloadSize), endianness: .big)
 
-        case .header(let channelID, let classID, let bodySize, let properties):
-            try encodeHeader(channelID: channelID, classID: classID, bodySize: bodySize, properties: properties, to: &buffer)
-        }
-    }
+    buffer.writeInteger(classID, endianness: .big)
+    buffer.writeInteger(UInt16(0), endianness: .big)  // weight (reserved)
+    buffer.writeInteger(bodySize, endianness: .big)
+    buffer.writeContiguousBytes(propsData)
 
-    private func encodeHeader(channelID: UInt16, classID: UInt16, bodySize: UInt64, properties: BasicProperties, to buffer: inout ByteBuffer) throws {
-        // Encode properties to temp buffer to get size
-        var propsEncoder = WireEncoder()
-        try properties.encode(to: &propsEncoder)
-        let propsData = propsEncoder.encodedData
+    buffer.writeInteger(frameEnd)
+  }
 
-        // Payload: classID(2) + weight(2) + bodySize(8) + properties(variable)
-        let payloadSize = 2 + 2 + 8 + propsData.count
+  private func encodeBasicPublish(
+    channelID: UInt16, publish: BasicPublish, to buffer: inout ByteBuffer
+  ) {
+    // Payload: classID(2) + methodID(2) + reserved1(2) + exchange(1+len) + routingKey(1+len) + flags(1)
+    let exchangeBytes = publish.exchange.utf8
+    let routingKeyBytes = publish.routingKey.utf8
+    let payloadSize = 2 + 2 + 2 + 1 + exchangeBytes.count + 1 + routingKeyBytes.count + 1
 
-        buffer.writeInteger(FrameType.header.rawValue)
-        buffer.writeInteger(channelID, endianness: .big)
-        buffer.writeInteger(UInt32(payloadSize), endianness: .big)
+    buffer.writeInteger(FrameType.method.rawValue)
+    buffer.writeInteger(channelID, endianness: .big)
+    buffer.writeInteger(UInt32(payloadSize), endianness: .big)
 
-        buffer.writeInteger(classID, endianness: .big)
-        buffer.writeInteger(UInt16(0), endianness: .big)  // weight (reserved)
-        buffer.writeInteger(bodySize, endianness: .big)
-        buffer.writeContiguousBytes(propsData)
+    // Class ID (60) and Method ID (40)
+    buffer.writeInteger(UInt16(60), endianness: .big)
+    buffer.writeInteger(UInt16(40), endianness: .big)
 
-        buffer.writeInteger(frameEnd)
-    }
+    // Reserved1
+    buffer.writeInteger(publish.reserved1, endianness: .big)
 
-    private func encodeBasicPublish(channelID: UInt16, publish: BasicPublish, to buffer: inout ByteBuffer) {
-        // Payload: classID(2) + methodID(2) + reserved1(2) + exchange(1+len) + routingKey(1+len) + flags(1)
-        let exchangeBytes = publish.exchange.utf8
-        let routingKeyBytes = publish.routingKey.utf8
-        let payloadSize = 2 + 2 + 2 + 1 + exchangeBytes.count + 1 + routingKeyBytes.count + 1
+    // Exchange (short string)
+    buffer.writeInteger(UInt8(exchangeBytes.count))
+    buffer.writeBytes(exchangeBytes)
 
-        buffer.writeInteger(FrameType.method.rawValue)
-        buffer.writeInteger(channelID, endianness: .big)
-        buffer.writeInteger(UInt32(payloadSize), endianness: .big)
+    // Routing key (short string)
+    buffer.writeInteger(UInt8(routingKeyBytes.count))
+    buffer.writeBytes(routingKeyBytes)
 
-        // Class ID (60) and Method ID (40)
-        buffer.writeInteger(UInt16(60), endianness: .big)
-        buffer.writeInteger(UInt16(40), endianness: .big)
+    // Flags (mandatory, immediate)
+    var flags: UInt8 = 0
+    if publish.mandatory { flags |= 0x01 }
+    if publish.immediate { flags |= 0x02 }
+    buffer.writeInteger(flags)
 
-        // Reserved1
-        buffer.writeInteger(publish.reserved1, endianness: .big)
-
-        // Exchange (short string)
-        buffer.writeInteger(UInt8(exchangeBytes.count))
-        buffer.writeBytes(exchangeBytes)
-
-        // Routing key (short string)
-        buffer.writeInteger(UInt8(routingKeyBytes.count))
-        buffer.writeBytes(routingKeyBytes)
-
-        // Flags (mandatory, immediate)
-        var flags: UInt8 = 0
-        if publish.mandatory { flags |= 0x01 }
-        if publish.immediate { flags |= 0x02 }
-        buffer.writeInteger(flags)
-
-        buffer.writeInteger(frameEnd)
-    }
+    buffer.writeInteger(frameEnd)
+  }
 }
 
 // MARK: - Protocol Header Handler
 
 final class ProtocolHeaderHandler: ChannelInboundHandler, RemovableChannelHandler {
-    typealias InboundIn = ByteBuffer
-    typealias InboundOut = Frame
+  typealias InboundIn = ByteBuffer
+  typealias InboundOut = Frame
 
-    private let promise: EventLoopPromise<Void>
-    private var buffer = Data()
+  private let promise: EventLoopPromise<Void>
+  private var buffer = Data()
 
-    init(promise: EventLoopPromise<Void>) {
-        self.promise = promise
+  init(promise: EventLoopPromise<Void>) {
+    self.promise = promise
+  }
+
+  func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    var buffer = unwrapInboundIn(data)
+
+    // Accumulate bytes
+    if let bytes = buffer.readBytes(length: buffer.readableBytes) {
+      self.buffer.append(contentsOf: bytes)
     }
 
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        var buffer = unwrapInboundIn(data)
-
-        // Accumulate bytes
-        if let bytes = buffer.readBytes(length: buffer.readableBytes) {
-            self.buffer.append(contentsOf: bytes)
+    // Check if we received the protocol header response
+    if self.buffer.count >= 8 {
+      if FrameCodec.isProtocolHeader(self.buffer) {
+        // Server sent protocol header back - version mismatch
+        if let version = try? FrameCodec.decodeProtocolHeader(self.buffer) {
+          promise.fail(
+            ConnectionError.protocolError(
+              "Server requires AMQP \(version.major).\(version.minor).\(version.revision)"
+            ))
+        } else {
+          promise.fail(ConnectionError.protocolError("Invalid protocol header from server"))
         }
+      } else {
+        // Put the data back for the frame decoder
+        var newBuffer = context.channel.allocator.buffer(capacity: self.buffer.count)
+        newBuffer.writeBytes(self.buffer)
+        context.fireChannelRead(NIOAny(newBuffer))
 
-        // Check if we received the protocol header response
-        if self.buffer.count >= 8 {
-            if FrameCodec.isProtocolHeader(self.buffer) {
-                // Server sent protocol header back - version mismatch
-                if let version = try? FrameCodec.decodeProtocolHeader(self.buffer) {
-                    promise.fail(ConnectionError.protocolError(
-                        "Server requires AMQP \(version.major).\(version.minor).\(version.revision)"
-                    ))
-                } else {
-                    promise.fail(ConnectionError.protocolError("Invalid protocol header from server"))
-                }
-            } else {
-                // Put the data back for the frame decoder
-                var newBuffer = context.channel.allocator.buffer(capacity: self.buffer.count)
-                newBuffer.writeBytes(self.buffer)
-                context.fireChannelRead(NIOAny(newBuffer))
-
-                promise.succeed(())
-            }
-        }
+        promise.succeed(())
+      }
     }
+  }
 
-    func errorCaught(context: ChannelHandlerContext, error: Error) {
-        promise.fail(error)
-        context.close(promise: nil)
-    }
+  func errorCaught(context: ChannelHandlerContext, error: Error) {
+    promise.fail(error)
+    context.close(promise: nil)
+  }
 }
 
 // MARK: - Connection State Handler
 
 /// Tracks connection state and handles connection-level methods
 final class ConnectionStateHandler: ChannelInboundHandler {
-    typealias InboundIn = Frame
-    typealias InboundOut = Frame
+  typealias InboundIn = Frame
+  typealias InboundOut = Frame
 
-    private let onClose: @Sendable (ConnectionClose) -> Void
-    private let onBlocked: @Sendable (String) -> Void
-    private let onUnblocked: @Sendable () -> Void
+  private let onClose: @Sendable (ConnectionClose) -> Void
+  private let onBlocked: @Sendable (String) -> Void
+  private let onUnblocked: @Sendable () -> Void
 
-    init(
-        onClose: @escaping @Sendable (ConnectionClose) -> Void,
-        onBlocked: @escaping @Sendable (String) -> Void,
-        onUnblocked: @escaping @Sendable () -> Void
-    ) {
-        self.onClose = onClose
-        self.onBlocked = onBlocked
-        self.onUnblocked = onUnblocked
+  init(
+    onClose: @escaping @Sendable (ConnectionClose) -> Void,
+    onBlocked: @escaping @Sendable (String) -> Void,
+    onUnblocked: @escaping @Sendable () -> Void
+  ) {
+    self.onClose = onClose
+    self.onBlocked = onBlocked
+    self.onUnblocked = onUnblocked
+  }
+
+  func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    let frame = unwrapInboundIn(data)
+
+    switch frame {
+    case .method(channelID: 0, method: .connectionClose(let close)):
+      onClose(close)
+    case .method(channelID: 0, method: .connectionBlocked(let blocked)):
+      onBlocked(blocked.reason)
+      context.fireChannelRead(data)
+    case .method(channelID: 0, method: .connectionUnblocked):
+      onUnblocked()
+      context.fireChannelRead(data)
+    default:
+      context.fireChannelRead(data)
     }
+  }
 
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        let frame = unwrapInboundIn(data)
-
-        switch frame {
-        case .method(channelID: 0, method: .connectionClose(let close)):
-            onClose(close)
-        case .method(channelID: 0, method: .connectionBlocked(let blocked)):
-            onBlocked(blocked.reason)
-            context.fireChannelRead(data)
-        case .method(channelID: 0, method: .connectionUnblocked):
-            onUnblocked()
-            context.fireChannelRead(data)
-        default:
-            context.fireChannelRead(data)
-        }
-    }
-
-    func errorCaught(context: ChannelHandlerContext, error: Error) {
-        context.fireErrorCaught(error)
-    }
+  func errorCaught(context: ChannelHandlerContext, error: Error) {
+    context.fireErrorCaught(error)
+  }
 }
 
 // MARK: - Heartbeat Handler
 
 /// Handles heartbeat frames
 final class HeartbeatHandler: ChannelDuplexHandler, RemovableChannelHandler, @unchecked Sendable {
-    typealias InboundIn = Frame
-    typealias InboundOut = Frame
-    typealias OutboundIn = Frame
-    typealias OutboundOut = Frame
+  typealias InboundIn = Frame
+  typealias InboundOut = Frame
+  typealias OutboundIn = Frame
+  typealias OutboundOut = Frame
 
-    private let interval: TimeAmount
-    private var lastReceived: NIODeadline
-    private var lastSent: NIODeadline
-    private var scheduledTask: Scheduled<Void>?
-    private let onTimeout: @Sendable () -> Void
+  private let interval: TimeAmount
+  private var lastReceived: NIODeadline
+  private var lastSent: NIODeadline
+  private var scheduledTask: Scheduled<Void>?
+  private let onTimeout: @Sendable () -> Void
 
-    init(interval: UInt16, onTimeout: @escaping @Sendable () -> Void) {
-        // Send heartbeat every interval/2 seconds
-        self.interval = .seconds(Int64(max(interval / 2, 1)))
-        self.lastReceived = .now()
-        self.lastSent = .now()
-        self.onTimeout = onTimeout
+  init(interval: UInt16, onTimeout: @escaping @Sendable () -> Void) {
+    // Send heartbeat every interval/2 seconds
+    self.interval = .seconds(Int64(max(interval / 2, 1)))
+    self.lastReceived = .now()
+    self.lastSent = .now()
+    self.onTimeout = onTimeout
+  }
+
+  func handlerAdded(context: ChannelHandlerContext) {
+    if interval.nanoseconds > 0 {
+      scheduleHeartbeat(context: context)
+    }
+  }
+
+  func handlerRemoved(context: ChannelHandlerContext) {
+    scheduledTask?.cancel()
+    scheduledTask = nil
+  }
+
+  func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    lastReceived = .now()
+
+    let frame = unwrapInboundIn(data)
+    if case .heartbeat = frame {
+      // Heartbeat received, don't propagate
+      return
+    }
+    context.fireChannelRead(data)
+  }
+
+  func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    lastSent = .now()
+    context.write(data, promise: promise)
+  }
+
+  private func scheduleHeartbeat(context: ChannelHandlerContext) {
+    scheduledTask = context.eventLoop.scheduleTask(in: interval) { [weak self] in
+      self?.checkHeartbeat(context: context)
+    }
+  }
+
+  private func checkHeartbeat(context: ChannelHandlerContext) {
+    let now = NIODeadline.now()
+
+    // Timeout after 4x the check interval (= 2x negotiated heartbeat)
+    let timeout = TimeAmount.nanoseconds(interval.nanoseconds * 4)
+    if now - lastReceived > timeout {
+      onTimeout()
+      context.close(promise: nil)
+      return
     }
 
-    func handlerAdded(context: ChannelHandlerContext) {
-        if interval.nanoseconds > 0 {
-            scheduleHeartbeat(context: context)
-        }
+    // Send heartbeat if we haven't sent anything recently
+    if now - lastSent > interval {
+      let frame = Frame.heartbeat
+      context.writeAndFlush(wrapOutboundOut(frame), promise: nil)
     }
 
-    func handlerRemoved(context: ChannelHandlerContext) {
-        scheduledTask?.cancel()
-        scheduledTask = nil
-    }
-
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        lastReceived = .now()
-
-        let frame = unwrapInboundIn(data)
-        if case .heartbeat = frame {
-            // Heartbeat received, don't propagate
-            return
-        }
-        context.fireChannelRead(data)
-    }
-
-    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        lastSent = .now()
-        context.write(data, promise: promise)
-    }
-
-    private func scheduleHeartbeat(context: ChannelHandlerContext) {
-        scheduledTask = context.eventLoop.scheduleTask(in: interval) { [weak self] in
-            self?.checkHeartbeat(context: context)
-        }
-    }
-
-    private func checkHeartbeat(context: ChannelHandlerContext) {
-        let now = NIODeadline.now()
-
-        // Timeout after 4x the check interval (= 2x negotiated heartbeat)
-        let timeout = TimeAmount.nanoseconds(interval.nanoseconds * 4)
-        if now - lastReceived > timeout {
-            onTimeout()
-            context.close(promise: nil)
-            return
-        }
-
-        // Send heartbeat if we haven't sent anything recently
-        if now - lastSent > interval {
-            let frame = Frame.heartbeat
-            context.writeAndFlush(wrapOutboundOut(frame), promise: nil)
-        }
-
-        scheduleHeartbeat(context: context)
-    }
+    scheduleHeartbeat(context: context)
+  }
 }

--- a/Sources/Transport/Transport.swift
+++ b/Sources/Transport/Transport.swift
@@ -5,6 +5,5 @@
 //
 // Copyright (c) 2025-2026 Michael S. Klishin
 
-import NIO
-
 @_exported import AMQPProtocol
+import NIO

--- a/Tests/AMQPProtocolTests/FrameCodecTests.swift
+++ b/Tests/AMQPProtocolTests/FrameCodecTests.swift
@@ -10,1275 +10,1298 @@
 
 import Foundation
 import Testing
+
 @testable import AMQPProtocol
 
 @Suite("Frame Type Tests")
 struct FrameTypeTests {
-    @Test("Frame type raw values")
-    func frameTypeRawValues() {
-        #expect(FrameType.method.rawValue == 1)
-        #expect(FrameType.header.rawValue == 2)
-        #expect(FrameType.body.rawValue == 3)
-        #expect(FrameType.heartbeat.rawValue == 8)
-    }
+  @Test("Frame type raw values")
+  func frameTypeRawValues() {
+    #expect(FrameType.method.rawValue == 1)
+    #expect(FrameType.header.rawValue == 2)
+    #expect(FrameType.body.rawValue == 3)
+    #expect(FrameType.heartbeat.rawValue == 8)
+  }
 
-    @Test("Frame channelID accessor")
-    func frameChannelID() {
-        let methodFrame = Frame.method(channelID: 5, method: .channelCloseOk)
-        #expect(methodFrame.channelID == 5)
+  @Test("Frame channelID accessor")
+  func frameChannelID() {
+    let methodFrame = Frame.method(channelID: 5, method: .channelCloseOk)
+    #expect(methodFrame.channelID == 5)
 
-        let headerFrame = Frame.header(channelID: 3, classID: 60, bodySize: 100, properties: BasicProperties())
-        #expect(headerFrame.channelID == 3)
+    let headerFrame = Frame.header(
+      channelID: 3, classID: 60, bodySize: 100, properties: BasicProperties())
+    #expect(headerFrame.channelID == 3)
 
-        let bodyFrame = Frame.body(channelID: 7, payload: Data())
-        #expect(bodyFrame.channelID == 7)
+    let bodyFrame = Frame.body(channelID: 7, payload: Data())
+    #expect(bodyFrame.channelID == 7)
 
-        let heartbeat = Frame.heartbeat
-        #expect(heartbeat.channelID == 0)
-    }
+    let heartbeat = Frame.heartbeat
+    #expect(heartbeat.channelID == 0)
+  }
 
-    @Test("Frame frameType accessor")
-    func frameFrameType() {
-        #expect(Frame.method(channelID: 0, method: .connectionCloseOk).frameType == .method)
-        #expect(Frame.header(channelID: 0, classID: 60, bodySize: 0, properties: BasicProperties()).frameType == .header)
-        #expect(Frame.body(channelID: 0, payload: Data()).frameType == .body)
-        #expect(Frame.heartbeat.frameType == .heartbeat)
-    }
+  @Test("Frame frameType accessor")
+  func frameFrameType() {
+    #expect(Frame.method(channelID: 0, method: .connectionCloseOk).frameType == .method)
+    #expect(
+      Frame.header(channelID: 0, classID: 60, bodySize: 0, properties: BasicProperties()).frameType
+        == .header)
+    #expect(Frame.body(channelID: 0, payload: Data()).frameType == .body)
+    #expect(Frame.heartbeat.frameType == .heartbeat)
+  }
 }
 
 @Suite("Heartbeat Frame Tests")
 struct HeartbeatFrameTests {
-    @Test("Encode heartbeat frame")
-    func encodeHeartbeat() throws {
-        let codec = FrameCodec()
-        let data = try codec.encode(.heartbeat)
-        // Type(1) + Channel(2) + Size(4) + FrameEnd(1) = 8 bytes
-        #expect(data.count == 8)
-        // Type 8, Channel 0, Size 0, FrameEnd 0xCE
-        #expect(data == Data([0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCE]))
-    }
+  @Test("Encode heartbeat frame")
+  func encodeHeartbeat() throws {
+    let codec = FrameCodec()
+    let data = try codec.encode(.heartbeat)
+    // Type(1) + Channel(2) + Size(4) + FrameEnd(1) = 8 bytes
+    #expect(data.count == 8)
+    // Type 8, Channel 0, Size 0, FrameEnd 0xCE
+    #expect(data == Data([0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCE]))
+  }
 
-    @Test("Decode heartbeat frame")
-    func decodeHeartbeat() throws {
-        let codec = FrameCodec()
-        var buffer = Data([0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCE])
-        let frame = try codec.decode(from: &buffer)
-        #expect(frame == .heartbeat)
-        #expect(buffer.isEmpty)
-    }
+  @Test("Decode heartbeat frame")
+  func decodeHeartbeat() throws {
+    let codec = FrameCodec()
+    var buffer = Data([0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCE])
+    let frame = try codec.decode(from: &buffer)
+    #expect(frame == .heartbeat)
+    #expect(buffer.isEmpty)
+  }
 
-    @Test("Heartbeat roundtrip")
-    func heartbeatRoundtrip() throws {
-        let codec = FrameCodec()
-        var data = try codec.encode(.heartbeat)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == .heartbeat)
-    }
+  @Test("Heartbeat roundtrip")
+  func heartbeatRoundtrip() throws {
+    let codec = FrameCodec()
+    var data = try codec.encode(.heartbeat)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == .heartbeat)
+  }
 }
 
 @Suite("Body Frame Tests")
 struct BodyFrameTests {
-    @Test("Encode body frame")
-    func encodeBody() throws {
-        let codec = FrameCodec()
-        let payload = Data([0x01, 0x02, 0x03, 0x04])
-        let data = try codec.encode(.body(channelID: 1, payload: payload))
-        // Header(7) + Payload(4) + FrameEnd(1) = 12 bytes
-        #expect(data.count == 12)
-    }
+  @Test("Encode body frame")
+  func encodeBody() throws {
+    let codec = FrameCodec()
+    let payload = Data([0x01, 0x02, 0x03, 0x04])
+    let data = try codec.encode(.body(channelID: 1, payload: payload))
+    // Header(7) + Payload(4) + FrameEnd(1) = 12 bytes
+    #expect(data.count == 12)
+  }
 
-    @Test("Body frame roundtrip")
-    func bodyRoundtrip() throws {
-        let codec = FrameCodec()
-        let original = Frame.body(channelID: 5, payload: Data([0xDE, 0xAD, 0xBE, 0xEF]))
-        var data = try codec.encode(original)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == original)
-    }
+  @Test("Body frame roundtrip")
+  func bodyRoundtrip() throws {
+    let codec = FrameCodec()
+    let original = Frame.body(channelID: 5, payload: Data([0xDE, 0xAD, 0xBE, 0xEF]))
+    var data = try codec.encode(original)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == original)
+  }
 
-    @Test("Empty body frame")
-    func emptyBody() throws {
-        let codec = FrameCodec()
-        let original = Frame.body(channelID: 1, payload: Data())
-        var data = try codec.encode(original)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == original)
-    }
+  @Test("Empty body frame")
+  func emptyBody() throws {
+    let codec = FrameCodec()
+    let original = Frame.body(channelID: 1, payload: Data())
+    var data = try codec.encode(original)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == original)
+  }
 
-    @Test("Large body frames are split")
-    func largeBodySplit() throws {
-        let codec = FrameCodec(maxFrameSize: 100)
-        let payload = Data(repeating: 0xAB, count: 200)
-        let frames = try codec.encodeBodyFrames(channelID: 1, payload: payload)
-        #expect(frames.count > 1)
+  @Test("Large body frames are split")
+  func largeBodySplit() throws {
+    let codec = FrameCodec(maxFrameSize: 100)
+    let payload = Data(repeating: 0xAB, count: 200)
+    let frames = try codec.encodeBodyFrames(channelID: 1, payload: payload)
+    #expect(frames.count > 1)
 
-        // Decode all frames and reassemble
-        var reassembled = Data()
-        for var frame in frames {
-            if let decoded = try codec.decode(from: &frame) {
-                if case .body(_, let data) = decoded {
-                    reassembled.append(data)
-                }
-            }
+    // Decode all frames and reassemble
+    var reassembled = Data()
+    for var frame in frames {
+      if let decoded = try codec.decode(from: &frame) {
+        if case .body(_, let data) = decoded {
+          reassembled.append(data)
         }
-        #expect(reassembled == payload)
+      }
     }
+    #expect(reassembled == payload)
+  }
 }
 
 @Suite("Header Frame Tests")
 struct HeaderFrameTests {
-    @Test("Encode header frame with empty properties")
-    func encodeEmptyHeader() throws {
-        let codec = FrameCodec()
-        let frame = Frame.header(channelID: 1, classID: 60, bodySize: 100, properties: BasicProperties())
-        let data = try codec.encode(frame)
-        #expect(data.count > 8)  // Header + class + weight + size + flags + frame end
+  @Test("Encode header frame with empty properties")
+  func encodeEmptyHeader() throws {
+    let codec = FrameCodec()
+    let frame = Frame.header(
+      channelID: 1, classID: 60, bodySize: 100, properties: BasicProperties())
+    let data = try codec.encode(frame)
+    #expect(data.count > 8)  // Header + class + weight + size + flags + frame end
+  }
+
+  @Test("Header frame roundtrip with properties")
+  func headerRoundtrip() throws {
+    let codec = FrameCodec()
+    let props = BasicProperties(
+      contentType: "application/json",
+      deliveryMode: .persistent,
+      priority: 5,
+      correlationId: "abc123",
+      messageId: "msg-001"
+    )
+    let frame = Frame.header(channelID: 3, classID: 60, bodySize: 1024, properties: props)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+
+    if case .header(let channelID, let classID, let bodySize, let decodedProps) = decoded {
+      #expect(channelID == 3)
+      #expect(classID == 60)
+      #expect(bodySize == 1024)
+      #expect(decodedProps.contentType == "application/json")
+      #expect(decodedProps.deliveryMode == .persistent)
+      #expect(decodedProps.priority == 5)
+      #expect(decodedProps.correlationId == "abc123")
+      #expect(decodedProps.messageId == "msg-001")
+    } else {
+      Issue.record("Expected header frame")
     }
+  }
 
-    @Test("Header frame roundtrip with properties")
-    func headerRoundtrip() throws {
-        let codec = FrameCodec()
-        let props = BasicProperties(
-            contentType: "application/json",
-            deliveryMode: .persistent,
-            priority: 5,
-            correlationId: "abc123",
-            messageId: "msg-001"
-        )
-        let frame = Frame.header(channelID: 3, classID: 60, bodySize: 1024, properties: props)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Header frame with all properties")
+  func headerAllProperties() throws {
+    let codec = FrameCodec()
+    let props = BasicProperties(
+      contentType: "text/plain",
+      contentEncoding: "utf-8",
+      headers: ["custom": .string("value")],
+      deliveryMode: .transient,
+      priority: 9,
+      correlationId: "corr-id",
+      replyTo: "reply-queue",
+      expiration: "60000",
+      messageId: "msg-id",
+      timestamp: Date(timeIntervalSince1970: 1_234_567_890),
+      type: "message.type",
+      userId: "guest",
+      appId: "my-app"
+    )
+    let frame = Frame.header(channelID: 1, classID: 60, bodySize: 0, properties: props)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .header(let channelID, let classID, let bodySize, let decodedProps) = decoded {
-            #expect(channelID == 3)
-            #expect(classID == 60)
-            #expect(bodySize == 1024)
-            #expect(decodedProps.contentType == "application/json")
-            #expect(decodedProps.deliveryMode == .persistent)
-            #expect(decodedProps.priority == 5)
-            #expect(decodedProps.correlationId == "abc123")
-            #expect(decodedProps.messageId == "msg-001")
-        } else {
-            Issue.record("Expected header frame")
-        }
+    if case .header(_, _, _, let decodedProps) = decoded {
+      #expect(decodedProps.contentType == props.contentType)
+      #expect(decodedProps.contentEncoding == props.contentEncoding)
+      #expect(decodedProps.headers?["custom"]?.stringValue == "value")
+      #expect(decodedProps.deliveryMode == props.deliveryMode)
+      #expect(decodedProps.priority == props.priority)
+      #expect(decodedProps.correlationId == props.correlationId)
+      #expect(decodedProps.replyTo == props.replyTo)
+      #expect(decodedProps.expiration == props.expiration)
+      #expect(decodedProps.messageId == props.messageId)
+      #expect(decodedProps.timestamp == props.timestamp)
+      #expect(decodedProps.type == props.type)
+      #expect(decodedProps.userId == props.userId)
+      #expect(decodedProps.appId == props.appId)
+    } else {
+      Issue.record("Expected header frame")
     }
-
-    @Test("Header frame with all properties")
-    func headerAllProperties() throws {
-        let codec = FrameCodec()
-        let props = BasicProperties(
-            contentType: "text/plain",
-            contentEncoding: "utf-8",
-            headers: ["custom": .string("value")],
-            deliveryMode: .transient,
-            priority: 9,
-            correlationId: "corr-id",
-            replyTo: "reply-queue",
-            expiration: "60000",
-            messageId: "msg-id",
-            timestamp: Date(timeIntervalSince1970: 1234567890),
-            type: "message.type",
-            userId: "guest",
-            appId: "my-app"
-        )
-        let frame = Frame.header(channelID: 1, classID: 60, bodySize: 0, properties: props)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-
-        if case .header(_, _, _, let decodedProps) = decoded {
-            #expect(decodedProps.contentType == props.contentType)
-            #expect(decodedProps.contentEncoding == props.contentEncoding)
-            #expect(decodedProps.headers?["custom"]?.stringValue == "value")
-            #expect(decodedProps.deliveryMode == props.deliveryMode)
-            #expect(decodedProps.priority == props.priority)
-            #expect(decodedProps.correlationId == props.correlationId)
-            #expect(decodedProps.replyTo == props.replyTo)
-            #expect(decodedProps.expiration == props.expiration)
-            #expect(decodedProps.messageId == props.messageId)
-            #expect(decodedProps.timestamp == props.timestamp)
-            #expect(decodedProps.type == props.type)
-            #expect(decodedProps.userId == props.userId)
-            #expect(decodedProps.appId == props.appId)
-        } else {
-            Issue.record("Expected header frame")
-        }
-    }
+  }
 }
 
 @Suite("Connection Method Frame Tests")
 struct ConnectionMethodTests {
-    @Test("Connection.Start roundtrip")
-    func connectionStart() throws {
-        let codec = FrameCodec()
-        let start = ConnectionStart(
-            versionMajor: 0,
-            versionMinor: 9,
-            serverProperties: ["product": .string("RabbitMQ")],
-            mechanisms: "PLAIN AMQPLAIN",
-            locales: "en_US"
-        )
-        let frame = Frame.method(channelID: 0, method: .connectionStart(start))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Connection.Start roundtrip")
+  func connectionStart() throws {
+    let codec = FrameCodec()
+    let start = ConnectionStart(
+      versionMajor: 0,
+      versionMinor: 9,
+      serverProperties: ["product": .string("RabbitMQ")],
+      mechanisms: "PLAIN AMQPLAIN",
+      locales: "en_US"
+    )
+    let frame = Frame.method(channelID: 0, method: .connectionStart(start))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(let ch, .connectionStart(let s)) = decoded {
-            #expect(ch == 0)
-            #expect(s.versionMajor == 0)
-            #expect(s.versionMinor == 9)
-            #expect(s.mechanisms == "PLAIN AMQPLAIN")
-            #expect(s.locales == "en_US")
-            #expect(s.serverProperties["product"]?.stringValue == "RabbitMQ")
-        } else {
-            Issue.record("Expected connectionStart")
-        }
+    if case .method(let ch, .connectionStart(let s)) = decoded {
+      #expect(ch == 0)
+      #expect(s.versionMajor == 0)
+      #expect(s.versionMinor == 9)
+      #expect(s.mechanisms == "PLAIN AMQPLAIN")
+      #expect(s.locales == "en_US")
+      #expect(s.serverProperties["product"]?.stringValue == "RabbitMQ")
+    } else {
+      Issue.record("Expected connectionStart")
     }
+  }
 
-    @Test("Connection.StartOk roundtrip")
-    func connectionStartOk() throws {
-        let codec = FrameCodec()
-        let startOk = ConnectionStartOk.plainAuth(
-            username: "guest",
-            password: "guest",
-            clientProperties: ["product": .string("BunnySwift")]
-        )
-        let frame = Frame.method(channelID: 0, method: .connectionStartOk(startOk))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Connection.StartOk roundtrip")
+  func connectionStartOk() throws {
+    let codec = FrameCodec()
+    let startOk = ConnectionStartOk.plainAuth(
+      username: "guest",
+      password: "guest",
+      clientProperties: ["product": .string("BunnySwift")]
+    )
+    let frame = Frame.method(channelID: 0, method: .connectionStartOk(startOk))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(let ch, .connectionStartOk(let s)) = decoded {
-            #expect(ch == 0)
-            #expect(s.mechanism == "PLAIN")
-            #expect(s.response == "\0guest\0guest")
-            #expect(s.locale == "en_US")
-        } else {
-            Issue.record("Expected connectionStartOk")
-        }
+    if case .method(let ch, .connectionStartOk(let s)) = decoded {
+      #expect(ch == 0)
+      #expect(s.mechanism == "PLAIN")
+      #expect(s.response == "\0guest\0guest")
+      #expect(s.locale == "en_US")
+    } else {
+      Issue.record("Expected connectionStartOk")
     }
+  }
 
-    @Test("Connection.Tune roundtrip")
-    func connectionTune() throws {
-        let codec = FrameCodec()
-        let tune = ConnectionTune(channelMax: 2047, frameMax: 131072, heartbeat: 60)
-        let frame = Frame.method(channelID: 0, method: .connectionTune(tune))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Connection.Tune roundtrip")
+  func connectionTune() throws {
+    let codec = FrameCodec()
+    let tune = ConnectionTune(channelMax: 2047, frameMax: 131072, heartbeat: 60)
+    let frame = Frame.method(channelID: 0, method: .connectionTune(tune))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .connectionTune(let t)) = decoded {
-            #expect(t.channelMax == 2047)
-            #expect(t.frameMax == 131072)
-            #expect(t.heartbeat == 60)
-        } else {
-            Issue.record("Expected connectionTune")
-        }
+    if case .method(_, .connectionTune(let t)) = decoded {
+      #expect(t.channelMax == 2047)
+      #expect(t.frameMax == 131072)
+      #expect(t.heartbeat == 60)
+    } else {
+      Issue.record("Expected connectionTune")
     }
+  }
 
-    @Test("Connection.TuneOk roundtrip")
-    func connectionTuneOk() throws {
-        let codec = FrameCodec()
-        let tuneOk = ConnectionTuneOk(channelMax: 1024, frameMax: 65536, heartbeat: 30)
-        let frame = Frame.method(channelID: 0, method: .connectionTuneOk(tuneOk))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Connection.TuneOk roundtrip")
+  func connectionTuneOk() throws {
+    let codec = FrameCodec()
+    let tuneOk = ConnectionTuneOk(channelMax: 1024, frameMax: 65536, heartbeat: 30)
+    let frame = Frame.method(channelID: 0, method: .connectionTuneOk(tuneOk))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .connectionTuneOk(let t)) = decoded {
-            #expect(t.channelMax == 1024)
-            #expect(t.frameMax == 65536)
-            #expect(t.heartbeat == 30)
-        } else {
-            Issue.record("Expected connectionTuneOk")
-        }
+    if case .method(_, .connectionTuneOk(let t)) = decoded {
+      #expect(t.channelMax == 1024)
+      #expect(t.frameMax == 65536)
+      #expect(t.heartbeat == 30)
+    } else {
+      Issue.record("Expected connectionTuneOk")
     }
+  }
 
-    @Test("Connection.Open roundtrip")
-    func connectionOpen() throws {
-        let codec = FrameCodec()
-        let open = ConnectionOpen(virtualHost: "/my-vhost")
-        let frame = Frame.method(channelID: 0, method: .connectionOpen(open))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Connection.Open roundtrip")
+  func connectionOpen() throws {
+    let codec = FrameCodec()
+    let open = ConnectionOpen(virtualHost: "/my-vhost")
+    let frame = Frame.method(channelID: 0, method: .connectionOpen(open))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .connectionOpen(let o)) = decoded {
-            #expect(o.virtualHost == "/my-vhost")
-        } else {
-            Issue.record("Expected connectionOpen")
-        }
+    if case .method(_, .connectionOpen(let o)) = decoded {
+      #expect(o.virtualHost == "/my-vhost")
+    } else {
+      Issue.record("Expected connectionOpen")
     }
+  }
 
-    @Test("Connection.OpenOk roundtrip")
-    func connectionOpenOk() throws {
-        let codec = FrameCodec()
-        let openOk = ConnectionOpenOk()
-        let frame = Frame.method(channelID: 0, method: .connectionOpenOk(openOk))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Connection.OpenOk roundtrip")
+  func connectionOpenOk() throws {
+    let codec = FrameCodec()
+    let openOk = ConnectionOpenOk()
+    let frame = Frame.method(channelID: 0, method: .connectionOpenOk(openOk))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .connectionOpenOk(_)) = decoded {
-            // Success
-        } else {
-            Issue.record("Expected connectionOpenOk")
-        }
+    if case .method(_, .connectionOpenOk(_)) = decoded {
+      // Success
+    } else {
+      Issue.record("Expected connectionOpenOk")
     }
+  }
 
-    @Test("Connection.Close roundtrip")
-    func connectionClose() throws {
-        let codec = FrameCodec()
-        let close = ConnectionClose(replyCode: 200, replyText: "Normal shutdown", classId: 0, methodId: 0)
-        let frame = Frame.method(channelID: 0, method: .connectionClose(close))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Connection.Close roundtrip")
+  func connectionClose() throws {
+    let codec = FrameCodec()
+    let close = ConnectionClose(
+      replyCode: 200, replyText: "Normal shutdown", classId: 0, methodId: 0)
+    let frame = Frame.method(channelID: 0, method: .connectionClose(close))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .connectionClose(let c)) = decoded {
-            #expect(c.replyCode == 200)
-            #expect(c.replyText == "Normal shutdown")
-        } else {
-            Issue.record("Expected connectionClose")
-        }
+    if case .method(_, .connectionClose(let c)) = decoded {
+      #expect(c.replyCode == 200)
+      #expect(c.replyText == "Normal shutdown")
+    } else {
+      Issue.record("Expected connectionClose")
     }
+  }
 
-    @Test("Connection.CloseOk roundtrip")
-    func connectionCloseOk() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 0, method: .connectionCloseOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
+  @Test("Connection.CloseOk roundtrip")
+  func connectionCloseOk() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 0, method: .connectionCloseOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
+
+  @Test("Connection.Blocked roundtrip")
+  func connectionBlocked() throws {
+    let codec = FrameCodec()
+    let blocked = ConnectionBlocked(reason: "resource-alarm")
+    let frame = Frame.method(channelID: 0, method: .connectionBlocked(blocked))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+
+    if case .method(_, .connectionBlocked(let b)) = decoded {
+      #expect(b.reason == "resource-alarm")
+    } else {
+      Issue.record("Expected connectionBlocked")
     }
+  }
 
-    @Test("Connection.Blocked roundtrip")
-    func connectionBlocked() throws {
-        let codec = FrameCodec()
-        let blocked = ConnectionBlocked(reason: "resource-alarm")
-        let frame = Frame.method(channelID: 0, method: .connectionBlocked(blocked))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-
-        if case .method(_, .connectionBlocked(let b)) = decoded {
-            #expect(b.reason == "resource-alarm")
-        } else {
-            Issue.record("Expected connectionBlocked")
-        }
-    }
-
-    @Test("Connection.Unblocked roundtrip")
-    func connectionUnblocked() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 0, method: .connectionUnblocked)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
-    }
+  @Test("Connection.Unblocked roundtrip")
+  func connectionUnblocked() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 0, method: .connectionUnblocked)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
 }
 
 @Suite("Channel Method Frame Tests")
 struct ChannelMethodTests {
-    @Test("Channel.Open roundtrip")
-    func channelOpen() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .channelOpen(ChannelOpen()))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Channel.Open roundtrip")
+  func channelOpen() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .channelOpen(ChannelOpen()))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(let ch, .channelOpen(_)) = decoded {
-            #expect(ch == 1)
-        } else {
-            Issue.record("Expected channelOpen")
-        }
+    if case .method(let ch, .channelOpen(_)) = decoded {
+      #expect(ch == 1)
+    } else {
+      Issue.record("Expected channelOpen")
     }
+  }
 
-    @Test("Channel.OpenOk roundtrip")
-    func channelOpenOk() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .channelOpenOk(ChannelOpenOk()))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Channel.OpenOk roundtrip")
+  func channelOpenOk() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .channelOpenOk(ChannelOpenOk()))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(let ch, .channelOpenOk(_)) = decoded {
-            #expect(ch == 1)
-        } else {
-            Issue.record("Expected channelOpenOk")
-        }
+    if case .method(let ch, .channelOpenOk(_)) = decoded {
+      #expect(ch == 1)
+    } else {
+      Issue.record("Expected channelOpenOk")
     }
+  }
 
-    @Test("Channel.Flow roundtrip")
-    func channelFlow() throws {
-        let codec = FrameCodec()
-        for active in [true, false] {
-            let frame = Frame.method(channelID: 1, method: .channelFlow(ChannelFlow(active: active)))
-            var data = try codec.encode(frame)
-            let decoded = try codec.decode(from: &data)
+  @Test("Channel.Flow roundtrip")
+  func channelFlow() throws {
+    let codec = FrameCodec()
+    for active in [true, false] {
+      let frame = Frame.method(channelID: 1, method: .channelFlow(ChannelFlow(active: active)))
+      var data = try codec.encode(frame)
+      let decoded = try codec.decode(from: &data)
 
-            if case .method(_, .channelFlow(let f)) = decoded {
-                #expect(f.active == active)
-            } else {
-                Issue.record("Expected channelFlow")
-            }
-        }
+      if case .method(_, .channelFlow(let f)) = decoded {
+        #expect(f.active == active)
+      } else {
+        Issue.record("Expected channelFlow")
+      }
     }
+  }
 
-    @Test("Channel.Close roundtrip")
-    func channelClose() throws {
-        let codec = FrameCodec()
-        let close = ChannelClose(replyCode: 404, replyText: "NOT_FOUND", classId: 50, methodId: 10)
-        let frame = Frame.method(channelID: 1, method: .channelClose(close))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Channel.Close roundtrip")
+  func channelClose() throws {
+    let codec = FrameCodec()
+    let close = ChannelClose(replyCode: 404, replyText: "NOT_FOUND", classId: 50, methodId: 10)
+    let frame = Frame.method(channelID: 1, method: .channelClose(close))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .channelClose(let c)) = decoded {
-            #expect(c.replyCode == 404)
-            #expect(c.replyText == "NOT_FOUND")
-            #expect(c.classId == 50)
-            #expect(c.methodId == 10)
-        } else {
-            Issue.record("Expected channelClose")
-        }
+    if case .method(_, .channelClose(let c)) = decoded {
+      #expect(c.replyCode == 404)
+      #expect(c.replyText == "NOT_FOUND")
+      #expect(c.classId == 50)
+      #expect(c.methodId == 10)
+    } else {
+      Issue.record("Expected channelClose")
     }
+  }
 
-    @Test("Channel.CloseOk roundtrip")
-    func channelCloseOk() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .channelCloseOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
-    }
+  @Test("Channel.CloseOk roundtrip")
+  func channelCloseOk() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .channelCloseOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
 }
 
 @Suite("Exchange Method Frame Tests")
 struct ExchangeMethodTests {
-    @Test("Exchange.Declare roundtrip")
-    func exchangeDeclare() throws {
-        let codec = FrameCodec()
-        let declare = ExchangeDeclare(
-            exchange: "my.exchange",
-            type: "topic",
-            passive: false,
-            durable: true,
-            autoDelete: false,
-            internal: false,
-            noWait: false,
-            arguments: ["alternate-exchange": .string("my.alt")]
-        )
-        let frame = Frame.method(channelID: 1, method: .exchangeDeclare(declare))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Exchange.Declare roundtrip")
+  func exchangeDeclare() throws {
+    let codec = FrameCodec()
+    let declare = ExchangeDeclare(
+      exchange: "my.exchange",
+      type: "topic",
+      passive: false,
+      durable: true,
+      autoDelete: false,
+      internal: false,
+      noWait: false,
+      arguments: ["alternate-exchange": .string("my.alt")]
+    )
+    let frame = Frame.method(channelID: 1, method: .exchangeDeclare(declare))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .exchangeDeclare(let d)) = decoded {
-            #expect(d.exchange == "my.exchange")
-            #expect(d.type == "topic")
-            #expect(d.durable == true)
-            #expect(d.arguments["alternate-exchange"]?.stringValue == "my.alt")
-        } else {
-            Issue.record("Expected exchangeDeclare")
-        }
+    if case .method(_, .exchangeDeclare(let d)) = decoded {
+      #expect(d.exchange == "my.exchange")
+      #expect(d.type == "topic")
+      #expect(d.durable == true)
+      #expect(d.arguments["alternate-exchange"]?.stringValue == "my.alt")
+    } else {
+      Issue.record("Expected exchangeDeclare")
     }
+  }
 
-    @Test("Exchange.DeclareOk roundtrip")
-    func exchangeDeclareOk() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .exchangeDeclareOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
+  @Test("Exchange.DeclareOk roundtrip")
+  func exchangeDeclareOk() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .exchangeDeclareOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
+
+  @Test("Exchange.Delete roundtrip")
+  func exchangeDelete() throws {
+    let codec = FrameCodec()
+    let delete = ExchangeDelete(exchange: "old.exchange", ifUnused: true)
+    let frame = Frame.method(channelID: 1, method: .exchangeDelete(delete))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+
+    if case .method(_, .exchangeDelete(let d)) = decoded {
+      #expect(d.exchange == "old.exchange")
+      #expect(d.ifUnused == true)
+    } else {
+      Issue.record("Expected exchangeDelete")
     }
+  }
 
-    @Test("Exchange.Delete roundtrip")
-    func exchangeDelete() throws {
-        let codec = FrameCodec()
-        let delete = ExchangeDelete(exchange: "old.exchange", ifUnused: true)
-        let frame = Frame.method(channelID: 1, method: .exchangeDelete(delete))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Exchange.Bind roundtrip")
+  func exchangeBind() throws {
+    let codec = FrameCodec()
+    let bind = ExchangeBind(destination: "dest", source: "src", routingKey: "key.*")
+    let frame = Frame.method(channelID: 1, method: .exchangeBind(bind))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .exchangeDelete(let d)) = decoded {
-            #expect(d.exchange == "old.exchange")
-            #expect(d.ifUnused == true)
-        } else {
-            Issue.record("Expected exchangeDelete")
-        }
+    if case .method(_, .exchangeBind(let b)) = decoded {
+      #expect(b.destination == "dest")
+      #expect(b.source == "src")
+      #expect(b.routingKey == "key.*")
+    } else {
+      Issue.record("Expected exchangeBind")
     }
+  }
 
-    @Test("Exchange.Bind roundtrip")
-    func exchangeBind() throws {
-        let codec = FrameCodec()
-        let bind = ExchangeBind(destination: "dest", source: "src", routingKey: "key.*")
-        let frame = Frame.method(channelID: 1, method: .exchangeBind(bind))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Exchange.Unbind roundtrip")
+  func exchangeUnbind() throws {
+    let codec = FrameCodec()
+    let unbind = ExchangeUnbind(destination: "dest", source: "src", routingKey: "key.*")
+    let frame = Frame.method(channelID: 1, method: .exchangeUnbind(unbind))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .exchangeBind(let b)) = decoded {
-            #expect(b.destination == "dest")
-            #expect(b.source == "src")
-            #expect(b.routingKey == "key.*")
-        } else {
-            Issue.record("Expected exchangeBind")
-        }
+    if case .method(_, .exchangeUnbind(let u)) = decoded {
+      #expect(u.destination == "dest")
+      #expect(u.source == "src")
+      #expect(u.routingKey == "key.*")
+    } else {
+      Issue.record("Expected exchangeUnbind")
     }
-
-    @Test("Exchange.Unbind roundtrip")
-    func exchangeUnbind() throws {
-        let codec = FrameCodec()
-        let unbind = ExchangeUnbind(destination: "dest", source: "src", routingKey: "key.*")
-        let frame = Frame.method(channelID: 1, method: .exchangeUnbind(unbind))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-
-        if case .method(_, .exchangeUnbind(let u)) = decoded {
-            #expect(u.destination == "dest")
-            #expect(u.source == "src")
-            #expect(u.routingKey == "key.*")
-        } else {
-            Issue.record("Expected exchangeUnbind")
-        }
-    }
+  }
 }
 
 @Suite("Queue Method Frame Tests")
 struct QueueMethodTests {
-    @Test("Queue.Declare roundtrip")
-    func queueDeclare() throws {
-        let codec = FrameCodec()
-        let declare = QueueDeclare(
-            queue: "my.queue",
-            passive: false,
-            durable: true,
-            exclusive: false,
-            autoDelete: false,
-            arguments: ["x-message-ttl": .int32(60000)]
-        )
-        let frame = Frame.method(channelID: 1, method: .queueDeclare(declare))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Queue.Declare roundtrip")
+  func queueDeclare() throws {
+    let codec = FrameCodec()
+    let declare = QueueDeclare(
+      queue: "my.queue",
+      passive: false,
+      durable: true,
+      exclusive: false,
+      autoDelete: false,
+      arguments: ["x-message-ttl": .int32(60000)]
+    )
+    let frame = Frame.method(channelID: 1, method: .queueDeclare(declare))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .queueDeclare(let d)) = decoded {
-            #expect(d.queue == "my.queue")
-            #expect(d.durable == true)
-            #expect(d.arguments["x-message-ttl"]?.intValue == 60000)
-        } else {
-            Issue.record("Expected queueDeclare")
-        }
+    if case .method(_, .queueDeclare(let d)) = decoded {
+      #expect(d.queue == "my.queue")
+      #expect(d.durable == true)
+      #expect(d.arguments["x-message-ttl"]?.intValue == 60000)
+    } else {
+      Issue.record("Expected queueDeclare")
     }
+  }
 
-    @Test("Queue.DeclareOk roundtrip")
-    func queueDeclareOk() throws {
-        let codec = FrameCodec()
-        let declareOk = QueueDeclareOk(queue: "amq.gen-abc123", messageCount: 100, consumerCount: 5)
-        let frame = Frame.method(channelID: 1, method: .queueDeclareOk(declareOk))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Queue.DeclareOk roundtrip")
+  func queueDeclareOk() throws {
+    let codec = FrameCodec()
+    let declareOk = QueueDeclareOk(queue: "amq.gen-abc123", messageCount: 100, consumerCount: 5)
+    let frame = Frame.method(channelID: 1, method: .queueDeclareOk(declareOk))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .queueDeclareOk(let d)) = decoded {
-            #expect(d.queue == "amq.gen-abc123")
-            #expect(d.messageCount == 100)
-            #expect(d.consumerCount == 5)
-        } else {
-            Issue.record("Expected queueDeclareOk")
-        }
+    if case .method(_, .queueDeclareOk(let d)) = decoded {
+      #expect(d.queue == "amq.gen-abc123")
+      #expect(d.messageCount == 100)
+      #expect(d.consumerCount == 5)
+    } else {
+      Issue.record("Expected queueDeclareOk")
     }
+  }
 
-    @Test("Queue.Bind roundtrip")
-    func queueBind() throws {
-        let codec = FrameCodec()
-        let bind = QueueBind(queue: "my.queue", exchange: "my.exchange", routingKey: "routing.key")
-        let frame = Frame.method(channelID: 1, method: .queueBind(bind))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Queue.Bind roundtrip")
+  func queueBind() throws {
+    let codec = FrameCodec()
+    let bind = QueueBind(queue: "my.queue", exchange: "my.exchange", routingKey: "routing.key")
+    let frame = Frame.method(channelID: 1, method: .queueBind(bind))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .queueBind(let b)) = decoded {
-            #expect(b.queue == "my.queue")
-            #expect(b.exchange == "my.exchange")
-            #expect(b.routingKey == "routing.key")
-        } else {
-            Issue.record("Expected queueBind")
-        }
+    if case .method(_, .queueBind(let b)) = decoded {
+      #expect(b.queue == "my.queue")
+      #expect(b.exchange == "my.exchange")
+      #expect(b.routingKey == "routing.key")
+    } else {
+      Issue.record("Expected queueBind")
     }
+  }
 
-    @Test("Queue.Unbind roundtrip")
-    func queueUnbind() throws {
-        let codec = FrameCodec()
-        let unbind = QueueUnbind(queue: "my.queue", exchange: "my.exchange", routingKey: "routing.key")
-        let frame = Frame.method(channelID: 1, method: .queueUnbind(unbind))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Queue.Unbind roundtrip")
+  func queueUnbind() throws {
+    let codec = FrameCodec()
+    let unbind = QueueUnbind(queue: "my.queue", exchange: "my.exchange", routingKey: "routing.key")
+    let frame = Frame.method(channelID: 1, method: .queueUnbind(unbind))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .queueUnbind(let u)) = decoded {
-            #expect(u.queue == "my.queue")
-            #expect(u.exchange == "my.exchange")
-            #expect(u.routingKey == "routing.key")
-        } else {
-            Issue.record("Expected queueUnbind")
-        }
+    if case .method(_, .queueUnbind(let u)) = decoded {
+      #expect(u.queue == "my.queue")
+      #expect(u.exchange == "my.exchange")
+      #expect(u.routingKey == "routing.key")
+    } else {
+      Issue.record("Expected queueUnbind")
     }
+  }
 
-    @Test("Queue.Purge roundtrip")
-    func queuePurge() throws {
-        let codec = FrameCodec()
-        let purge = QueuePurge(queue: "my.queue")
-        let frame = Frame.method(channelID: 1, method: .queuePurge(purge))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Queue.Purge roundtrip")
+  func queuePurge() throws {
+    let codec = FrameCodec()
+    let purge = QueuePurge(queue: "my.queue")
+    let frame = Frame.method(channelID: 1, method: .queuePurge(purge))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .queuePurge(let p)) = decoded {
-            #expect(p.queue == "my.queue")
-        } else {
-            Issue.record("Expected queuePurge")
-        }
+    if case .method(_, .queuePurge(let p)) = decoded {
+      #expect(p.queue == "my.queue")
+    } else {
+      Issue.record("Expected queuePurge")
     }
+  }
 
-    @Test("Queue.PurgeOk roundtrip")
-    func queuePurgeOk() throws {
-        let codec = FrameCodec()
-        let purgeOk = QueuePurgeOk(messageCount: 42)
-        let frame = Frame.method(channelID: 1, method: .queuePurgeOk(purgeOk))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Queue.PurgeOk roundtrip")
+  func queuePurgeOk() throws {
+    let codec = FrameCodec()
+    let purgeOk = QueuePurgeOk(messageCount: 42)
+    let frame = Frame.method(channelID: 1, method: .queuePurgeOk(purgeOk))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .queuePurgeOk(let p)) = decoded {
-            #expect(p.messageCount == 42)
-        } else {
-            Issue.record("Expected queuePurgeOk")
-        }
+    if case .method(_, .queuePurgeOk(let p)) = decoded {
+      #expect(p.messageCount == 42)
+    } else {
+      Issue.record("Expected queuePurgeOk")
     }
+  }
 
-    @Test("Queue.Delete roundtrip")
-    func queueDelete() throws {
-        let codec = FrameCodec()
-        let delete = QueueDelete(queue: "my.queue", ifUnused: true, ifEmpty: true)
-        let frame = Frame.method(channelID: 1, method: .queueDelete(delete))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Queue.Delete roundtrip")
+  func queueDelete() throws {
+    let codec = FrameCodec()
+    let delete = QueueDelete(queue: "my.queue", ifUnused: true, ifEmpty: true)
+    let frame = Frame.method(channelID: 1, method: .queueDelete(delete))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .queueDelete(let d)) = decoded {
-            #expect(d.queue == "my.queue")
-            #expect(d.ifUnused == true)
-            #expect(d.ifEmpty == true)
-        } else {
-            Issue.record("Expected queueDelete")
-        }
+    if case .method(_, .queueDelete(let d)) = decoded {
+      #expect(d.queue == "my.queue")
+      #expect(d.ifUnused == true)
+      #expect(d.ifEmpty == true)
+    } else {
+      Issue.record("Expected queueDelete")
     }
+  }
 
-    @Test("Queue.DeleteOk roundtrip")
-    func queueDeleteOk() throws {
-        let codec = FrameCodec()
-        let deleteOk = QueueDeleteOk(messageCount: 10)
-        let frame = Frame.method(channelID: 1, method: .queueDeleteOk(deleteOk))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Queue.DeleteOk roundtrip")
+  func queueDeleteOk() throws {
+    let codec = FrameCodec()
+    let deleteOk = QueueDeleteOk(messageCount: 10)
+    let frame = Frame.method(channelID: 1, method: .queueDeleteOk(deleteOk))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .queueDeleteOk(let d)) = decoded {
-            #expect(d.messageCount == 10)
-        } else {
-            Issue.record("Expected queueDeleteOk")
-        }
+    if case .method(_, .queueDeleteOk(let d)) = decoded {
+      #expect(d.messageCount == 10)
+    } else {
+      Issue.record("Expected queueDeleteOk")
     }
+  }
 }
 
 @Suite("Basic Method Frame Tests")
 struct BasicMethodTests {
-    @Test("Basic.Qos roundtrip")
-    func basicQos() throws {
-        let codec = FrameCodec()
-        let qos = BasicQos(prefetchSize: 0, prefetchCount: 10, global: true)
-        let frame = Frame.method(channelID: 1, method: .basicQos(qos))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.Qos roundtrip")
+  func basicQos() throws {
+    let codec = FrameCodec()
+    let qos = BasicQos(prefetchSize: 0, prefetchCount: 10, global: true)
+    let frame = Frame.method(channelID: 1, method: .basicQos(qos))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicQos(let q)) = decoded {
-            #expect(q.prefetchCount == 10)
-            #expect(q.global == true)
-        } else {
-            Issue.record("Expected basicQos")
-        }
+    if case .method(_, .basicQos(let q)) = decoded {
+      #expect(q.prefetchCount == 10)
+      #expect(q.global == true)
+    } else {
+      Issue.record("Expected basicQos")
     }
+  }
 
-    @Test("Basic.QosOk roundtrip")
-    func basicQosOk() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .basicQosOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
+  @Test("Basic.QosOk roundtrip")
+  func basicQosOk() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .basicQosOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
+
+  @Test("Basic.Consume roundtrip")
+  func basicConsume() throws {
+    let codec = FrameCodec()
+    let consume = BasicConsume(
+      queue: "my.queue",
+      consumerTag: "consumer-1",
+      noLocal: false,
+      noAck: false,
+      exclusive: true
+    )
+    let frame = Frame.method(channelID: 1, method: .basicConsume(consume))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+
+    if case .method(_, .basicConsume(let c)) = decoded {
+      #expect(c.queue == "my.queue")
+      #expect(c.consumerTag == "consumer-1")
+      #expect(c.exclusive == true)
+    } else {
+      Issue.record("Expected basicConsume")
     }
+  }
 
-    @Test("Basic.Consume roundtrip")
-    func basicConsume() throws {
-        let codec = FrameCodec()
-        let consume = BasicConsume(
-            queue: "my.queue",
-            consumerTag: "consumer-1",
-            noLocal: false,
-            noAck: false,
-            exclusive: true
-        )
-        let frame = Frame.method(channelID: 1, method: .basicConsume(consume))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.ConsumeOk roundtrip")
+  func basicConsumeOk() throws {
+    let codec = FrameCodec()
+    let consumeOk = BasicConsumeOk(consumerTag: "consumer-1")
+    let frame = Frame.method(channelID: 1, method: .basicConsumeOk(consumeOk))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicConsume(let c)) = decoded {
-            #expect(c.queue == "my.queue")
-            #expect(c.consumerTag == "consumer-1")
-            #expect(c.exclusive == true)
-        } else {
-            Issue.record("Expected basicConsume")
-        }
+    if case .method(_, .basicConsumeOk(let c)) = decoded {
+      #expect(c.consumerTag == "consumer-1")
+    } else {
+      Issue.record("Expected basicConsumeOk")
     }
+  }
 
-    @Test("Basic.ConsumeOk roundtrip")
-    func basicConsumeOk() throws {
-        let codec = FrameCodec()
-        let consumeOk = BasicConsumeOk(consumerTag: "consumer-1")
-        let frame = Frame.method(channelID: 1, method: .basicConsumeOk(consumeOk))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.Cancel roundtrip")
+  func basicCancel() throws {
+    let codec = FrameCodec()
+    let cancel = BasicCancel(consumerTag: "consumer-1", noWait: false)
+    let frame = Frame.method(channelID: 1, method: .basicCancel(cancel))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicConsumeOk(let c)) = decoded {
-            #expect(c.consumerTag == "consumer-1")
-        } else {
-            Issue.record("Expected basicConsumeOk")
-        }
+    if case .method(_, .basicCancel(let c)) = decoded {
+      #expect(c.consumerTag == "consumer-1")
+    } else {
+      Issue.record("Expected basicCancel")
     }
+  }
 
-    @Test("Basic.Cancel roundtrip")
-    func basicCancel() throws {
-        let codec = FrameCodec()
-        let cancel = BasicCancel(consumerTag: "consumer-1", noWait: false)
-        let frame = Frame.method(channelID: 1, method: .basicCancel(cancel))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.Publish roundtrip")
+  func basicPublish() throws {
+    let codec = FrameCodec()
+    let publish = BasicPublish(exchange: "my.exchange", routingKey: "routing.key", mandatory: true)
+    let frame = Frame.method(channelID: 1, method: .basicPublish(publish))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicCancel(let c)) = decoded {
-            #expect(c.consumerTag == "consumer-1")
-        } else {
-            Issue.record("Expected basicCancel")
-        }
+    if case .method(_, .basicPublish(let p)) = decoded {
+      #expect(p.exchange == "my.exchange")
+      #expect(p.routingKey == "routing.key")
+      #expect(p.mandatory == true)
+    } else {
+      Issue.record("Expected basicPublish")
     }
+  }
 
-    @Test("Basic.Publish roundtrip")
-    func basicPublish() throws {
-        let codec = FrameCodec()
-        let publish = BasicPublish(exchange: "my.exchange", routingKey: "routing.key", mandatory: true)
-        let frame = Frame.method(channelID: 1, method: .basicPublish(publish))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.Return roundtrip")
+  func basicReturn() throws {
+    let codec = FrameCodec()
+    let ret = BasicReturn(
+      replyCode: 312, replyText: "NO_ROUTE", exchange: "my.exchange", routingKey: "key")
+    let frame = Frame.method(channelID: 1, method: .basicReturn(ret))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicPublish(let p)) = decoded {
-            #expect(p.exchange == "my.exchange")
-            #expect(p.routingKey == "routing.key")
-            #expect(p.mandatory == true)
-        } else {
-            Issue.record("Expected basicPublish")
-        }
+    if case .method(_, .basicReturn(let r)) = decoded {
+      #expect(r.replyCode == 312)
+      #expect(r.replyText == "NO_ROUTE")
+    } else {
+      Issue.record("Expected basicReturn")
     }
+  }
 
-    @Test("Basic.Return roundtrip")
-    func basicReturn() throws {
-        let codec = FrameCodec()
-        let ret = BasicReturn(replyCode: 312, replyText: "NO_ROUTE", exchange: "my.exchange", routingKey: "key")
-        let frame = Frame.method(channelID: 1, method: .basicReturn(ret))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.Deliver roundtrip")
+  func basicDeliver() throws {
+    let codec = FrameCodec()
+    let deliver = BasicDeliver(
+      consumerTag: "consumer-1",
+      deliveryTag: 12345,
+      redelivered: true,
+      exchange: "my.exchange",
+      routingKey: "routing.key"
+    )
+    let frame = Frame.method(channelID: 1, method: .basicDeliver(deliver))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicReturn(let r)) = decoded {
-            #expect(r.replyCode == 312)
-            #expect(r.replyText == "NO_ROUTE")
-        } else {
-            Issue.record("Expected basicReturn")
-        }
+    if case .method(_, .basicDeliver(let d)) = decoded {
+      #expect(d.consumerTag == "consumer-1")
+      #expect(d.deliveryTag == 12345)
+      #expect(d.redelivered == true)
+      #expect(d.exchange == "my.exchange")
+      #expect(d.routingKey == "routing.key")
+    } else {
+      Issue.record("Expected basicDeliver")
     }
+  }
 
-    @Test("Basic.Deliver roundtrip")
-    func basicDeliver() throws {
-        let codec = FrameCodec()
-        let deliver = BasicDeliver(
-            consumerTag: "consumer-1",
-            deliveryTag: 12345,
-            redelivered: true,
-            exchange: "my.exchange",
-            routingKey: "routing.key"
-        )
-        let frame = Frame.method(channelID: 1, method: .basicDeliver(deliver))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.Get roundtrip")
+  func basicGet() throws {
+    let codec = FrameCodec()
+    let get = BasicGet(queue: "my.queue", noAck: true)
+    let frame = Frame.method(channelID: 1, method: .basicGet(get))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicDeliver(let d)) = decoded {
-            #expect(d.consumerTag == "consumer-1")
-            #expect(d.deliveryTag == 12345)
-            #expect(d.redelivered == true)
-            #expect(d.exchange == "my.exchange")
-            #expect(d.routingKey == "routing.key")
-        } else {
-            Issue.record("Expected basicDeliver")
-        }
+    if case .method(_, .basicGet(let g)) = decoded {
+      #expect(g.queue == "my.queue")
+      #expect(g.noAck == true)
+    } else {
+      Issue.record("Expected basicGet")
     }
+  }
 
-    @Test("Basic.Get roundtrip")
-    func basicGet() throws {
-        let codec = FrameCodec()
-        let get = BasicGet(queue: "my.queue", noAck: true)
-        let frame = Frame.method(channelID: 1, method: .basicGet(get))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.GetOk roundtrip")
+  func basicGetOk() throws {
+    let codec = FrameCodec()
+    let getOk = BasicGetOk(
+      deliveryTag: 42, redelivered: false, exchange: "ex", routingKey: "key", messageCount: 10)
+    let frame = Frame.method(channelID: 1, method: .basicGetOk(getOk))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicGet(let g)) = decoded {
-            #expect(g.queue == "my.queue")
-            #expect(g.noAck == true)
-        } else {
-            Issue.record("Expected basicGet")
-        }
+    if case .method(_, .basicGetOk(let g)) = decoded {
+      #expect(g.deliveryTag == 42)
+      #expect(g.messageCount == 10)
+    } else {
+      Issue.record("Expected basicGetOk")
     }
+  }
 
-    @Test("Basic.GetOk roundtrip")
-    func basicGetOk() throws {
-        let codec = FrameCodec()
-        let getOk = BasicGetOk(deliveryTag: 42, redelivered: false, exchange: "ex", routingKey: "key", messageCount: 10)
-        let frame = Frame.method(channelID: 1, method: .basicGetOk(getOk))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.GetEmpty roundtrip")
+  func basicGetEmpty() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .basicGetEmpty(BasicGetEmpty()))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicGetOk(let g)) = decoded {
-            #expect(g.deliveryTag == 42)
-            #expect(g.messageCount == 10)
-        } else {
-            Issue.record("Expected basicGetOk")
-        }
+    if case .method(_, .basicGetEmpty(_)) = decoded {
+      // Success
+    } else {
+      Issue.record("Expected basicGetEmpty")
     }
+  }
 
-    @Test("Basic.GetEmpty roundtrip")
-    func basicGetEmpty() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .basicGetEmpty(BasicGetEmpty()))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.Ack roundtrip")
+  func basicAck() throws {
+    let codec = FrameCodec()
+    let ack = BasicAck(deliveryTag: 42, multiple: true)
+    let frame = Frame.method(channelID: 1, method: .basicAck(ack))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicGetEmpty(_)) = decoded {
-            // Success
-        } else {
-            Issue.record("Expected basicGetEmpty")
-        }
+    if case .method(_, .basicAck(let a)) = decoded {
+      #expect(a.deliveryTag == 42)
+      #expect(a.multiple == true)
+    } else {
+      Issue.record("Expected basicAck")
     }
+  }
 
-    @Test("Basic.Ack roundtrip")
-    func basicAck() throws {
-        let codec = FrameCodec()
-        let ack = BasicAck(deliveryTag: 42, multiple: true)
-        let frame = Frame.method(channelID: 1, method: .basicAck(ack))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.Reject roundtrip")
+  func basicReject() throws {
+    let codec = FrameCodec()
+    let reject = BasicReject(deliveryTag: 42, requeue: true)
+    let frame = Frame.method(channelID: 1, method: .basicReject(reject))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicAck(let a)) = decoded {
-            #expect(a.deliveryTag == 42)
-            #expect(a.multiple == true)
-        } else {
-            Issue.record("Expected basicAck")
-        }
+    if case .method(_, .basicReject(let r)) = decoded {
+      #expect(r.deliveryTag == 42)
+      #expect(r.requeue == true)
+    } else {
+      Issue.record("Expected basicReject")
     }
+  }
 
-    @Test("Basic.Reject roundtrip")
-    func basicReject() throws {
-        let codec = FrameCodec()
-        let reject = BasicReject(deliveryTag: 42, requeue: true)
-        let frame = Frame.method(channelID: 1, method: .basicReject(reject))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.Nack roundtrip")
+  func basicNack() throws {
+    let codec = FrameCodec()
+    let nack = BasicNack(deliveryTag: 42, multiple: true, requeue: false)
+    let frame = Frame.method(channelID: 1, method: .basicNack(nack))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicReject(let r)) = decoded {
-            #expect(r.deliveryTag == 42)
-            #expect(r.requeue == true)
-        } else {
-            Issue.record("Expected basicReject")
-        }
+    if case .method(_, .basicNack(let n)) = decoded {
+      #expect(n.deliveryTag == 42)
+      #expect(n.multiple == true)
+      #expect(n.requeue == false)
+    } else {
+      Issue.record("Expected basicNack")
     }
+  }
 
-    @Test("Basic.Nack roundtrip")
-    func basicNack() throws {
-        let codec = FrameCodec()
-        let nack = BasicNack(deliveryTag: 42, multiple: true, requeue: false)
-        let frame = Frame.method(channelID: 1, method: .basicNack(nack))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Basic.Recover roundtrip")
+  func basicRecover() throws {
+    let codec = FrameCodec()
+    let recover = BasicRecover(requeue: true)
+    let frame = Frame.method(channelID: 1, method: .basicRecover(recover))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .basicNack(let n)) = decoded {
-            #expect(n.deliveryTag == 42)
-            #expect(n.multiple == true)
-            #expect(n.requeue == false)
-        } else {
-            Issue.record("Expected basicNack")
-        }
+    if case .method(_, .basicRecover(let r)) = decoded {
+      #expect(r.requeue == true)
+    } else {
+      Issue.record("Expected basicRecover")
     }
+  }
 
-    @Test("Basic.Recover roundtrip")
-    func basicRecover() throws {
-        let codec = FrameCodec()
-        let recover = BasicRecover(requeue: true)
-        let frame = Frame.method(channelID: 1, method: .basicRecover(recover))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-
-        if case .method(_, .basicRecover(let r)) = decoded {
-            #expect(r.requeue == true)
-        } else {
-            Issue.record("Expected basicRecover")
-        }
-    }
-
-    @Test("Basic.RecoverOk roundtrip")
-    func basicRecoverOk() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .basicRecoverOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
-    }
+  @Test("Basic.RecoverOk roundtrip")
+  func basicRecoverOk() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .basicRecoverOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
 }
 
 @Suite("Tx Method Frame Tests")
 struct TxMethodTests {
-    @Test("Tx.Select roundtrip")
-    func txSelect() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .txSelect)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
-    }
+  @Test("Tx.Select roundtrip")
+  func txSelect() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .txSelect)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
 
-    @Test("Tx.SelectOk roundtrip")
-    func txSelectOk() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .txSelectOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
-    }
+  @Test("Tx.SelectOk roundtrip")
+  func txSelectOk() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .txSelectOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
 
-    @Test("Tx.Commit roundtrip")
-    func txCommit() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .txCommit)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
-    }
+  @Test("Tx.Commit roundtrip")
+  func txCommit() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .txCommit)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
 
-    @Test("Tx.CommitOk roundtrip")
-    func txCommitOk() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .txCommitOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
-    }
+  @Test("Tx.CommitOk roundtrip")
+  func txCommitOk() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .txCommitOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
 
-    @Test("Tx.Rollback roundtrip")
-    func txRollback() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .txRollback)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
-    }
+  @Test("Tx.Rollback roundtrip")
+  func txRollback() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .txRollback)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
 
-    @Test("Tx.RollbackOk roundtrip")
-    func txRollbackOk() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .txRollbackOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
-    }
+  @Test("Tx.RollbackOk roundtrip")
+  func txRollbackOk() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .txRollbackOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
 }
 
 @Suite("Confirm Method Frame Tests")
 struct ConfirmMethodTests {
-    @Test("Confirm.Select roundtrip")
-    func confirmSelect() throws {
-        let codec = FrameCodec()
-        let confirm = ConfirmSelect(noWait: false)
-        let frame = Frame.method(channelID: 1, method: .confirmSelect(confirm))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Confirm.Select roundtrip")
+  func confirmSelect() throws {
+    let codec = FrameCodec()
+    let confirm = ConfirmSelect(noWait: false)
+    let frame = Frame.method(channelID: 1, method: .confirmSelect(confirm))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(_, .confirmSelect(let c)) = decoded {
-            #expect(c.noWait == false)
-        } else {
-            Issue.record("Expected confirmSelect")
-        }
+    if case .method(_, .confirmSelect(let c)) = decoded {
+      #expect(c.noWait == false)
+    } else {
+      Issue.record("Expected confirmSelect")
     }
+  }
 
-    @Test("Confirm.SelectOk roundtrip")
-    func confirmSelectOk() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 1, method: .confirmSelectOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-        #expect(decoded == frame)
-    }
+  @Test("Confirm.SelectOk roundtrip")
+  func confirmSelectOk() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 1, method: .confirmSelectOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+    #expect(decoded == frame)
+  }
 }
 
 @Suite("Protocol Header Tests")
 struct ProtocolHeaderTests {
-    @Test("Detect protocol header")
-    func detectProtocolHeader() {
-        let header = Data([0x41, 0x4D, 0x51, 0x50, 0x00, 0x00, 0x09, 0x01])
-        #expect(FrameCodec.isProtocolHeader(header) == true)
+  @Test("Detect protocol header")
+  func detectProtocolHeader() {
+    let header = Data([0x41, 0x4D, 0x51, 0x50, 0x00, 0x00, 0x09, 0x01])
+    #expect(FrameCodec.isProtocolHeader(header) == true)
 
-        let notHeader = Data([0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCE])
-        #expect(FrameCodec.isProtocolHeader(notHeader) == false)
-    }
+    let notHeader = Data([0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCE])
+    #expect(FrameCodec.isProtocolHeader(notHeader) == false)
+  }
 
-    @Test("Decode protocol header")
-    func decodeProtocolHeader() throws {
-        let header = Data([0x41, 0x4D, 0x51, 0x50, 0x00, 0x00, 0x09, 0x01])
-        let version = try FrameCodec.decodeProtocolHeader(header)
-        #expect(version?.major == 0)
-        #expect(version?.minor == 9)
-        #expect(version?.revision == 1)
-    }
+  @Test("Decode protocol header")
+  func decodeProtocolHeader() throws {
+    let header = Data([0x41, 0x4D, 0x51, 0x50, 0x00, 0x00, 0x09, 0x01])
+    let version = try FrameCodec.decodeProtocolHeader(header)
+    #expect(version?.major == 0)
+    #expect(version?.minor == 9)
+    #expect(version?.revision == 1)
+  }
 }
 
 @Suite("Frame Codec Edge Cases")
 struct FrameCodecEdgeCaseTests {
-    @Test("Incomplete frame returns nil")
-    func incompleteFrame() throws {
-        let codec = FrameCodec()
-        var buffer = Data([0x08, 0x00, 0x00])  // Incomplete heartbeat
-        let frame = try codec.decode(from: &buffer)
-        #expect(frame == nil)
-        #expect(buffer.count == 3)  // Buffer unchanged
+  @Test("Incomplete frame returns nil")
+  func incompleteFrame() throws {
+    let codec = FrameCodec()
+    var buffer = Data([0x08, 0x00, 0x00])  // Incomplete heartbeat
+    let frame = try codec.decode(from: &buffer)
+    #expect(frame == nil)
+    #expect(buffer.count == 3)  // Buffer unchanged
+  }
+
+  @Test("Invalid frame end throws error")
+  func invalidFrameEnd() {
+    let codec = FrameCodec()
+    var buffer = Data([0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF])  // Wrong frame end
+    #expect(throws: WireFormatError.self) {
+      _ = try codec.decode(from: &buffer)
     }
+  }
 
-    @Test("Invalid frame end throws error")
-    func invalidFrameEnd() {
-        let codec = FrameCodec()
-        var buffer = Data([0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF])  // Wrong frame end
-        #expect(throws: WireFormatError.self) {
-            _ = try codec.decode(from: &buffer)
-        }
+  @Test("Unknown frame type throws error")
+  func unknownFrameType() {
+    let codec = FrameCodec()
+    var buffer = Data([0x99, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCE])  // Unknown type
+    #expect(throws: WireFormatError.self) {
+      _ = try codec.decode(from: &buffer)
     }
+  }
 
-    @Test("Unknown frame type throws error")
-    func unknownFrameType() {
-        let codec = FrameCodec()
-        var buffer = Data([0x99, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCE])  // Unknown type
-        #expect(throws: WireFormatError.self) {
-            _ = try codec.decode(from: &buffer)
-        }
+  @Test("Frame too large on encode throws error")
+  func frameTooLargeEncode() {
+    let codec = FrameCodec(maxFrameSize: 100)
+    let largePayload = Data(repeating: 0xAB, count: 200)
+    #expect(throws: WireFormatError.self) {
+      _ = try codec.encode(.body(channelID: 1, payload: largePayload))
     }
+  }
 
-    @Test("Frame too large on encode throws error")
-    func frameTooLargeEncode() {
-        let codec = FrameCodec(maxFrameSize: 100)
-        let largePayload = Data(repeating: 0xAB, count: 200)
-        #expect(throws: WireFormatError.self) {
-            _ = try codec.encode(.body(channelID: 1, payload: largePayload))
-        }
+  @Test("Frame too large on decode throws error")
+  func frameTooLargeDecode() {
+    let codec = FrameCodec(maxFrameSize: 100)
+    // Craft a frame header claiming a payload size larger than allowed
+    // Type=body(3), Channel=1, Size=0x00001000 (4096 bytes)
+    // Need at least FrameDefaults.headerSize + 1 (= 8 bytes) to pass initial check
+    var buffer = Data([
+      0x03,  // body frame type
+      0x00, 0x01,  // channel 1
+      0x00, 0x00, 0x10, 0x00,  // size = 4096 (way over 100 limit)
+      0xCE,  // frame end (won't be reached)
+    ])
+    #expect(throws: WireFormatError.self) {
+      _ = try codec.decode(from: &buffer)
     }
+  }
 
-    @Test("Frame too large on decode throws error")
-    func frameTooLargeDecode() {
-        let codec = FrameCodec(maxFrameSize: 100)
-        // Craft a frame header claiming a payload size larger than allowed
-        // Type=body(3), Channel=1, Size=0x00001000 (4096 bytes)
-        // Need at least FrameDefaults.headerSize + 1 (= 8 bytes) to pass initial check
-        var buffer = Data([
-            0x03,                      // body frame type
-            0x00, 0x01,                // channel 1
-            0x00, 0x00, 0x10, 0x00,    // size = 4096 (way over 100 limit)
-            0xCE                       // frame end (won't be reached)
-        ])
-        #expect(throws: WireFormatError.self) {
-            _ = try codec.decode(from: &buffer)
-        }
+  @Test("Unknown method throws error")
+  func unknownMethod() {
+    let codec = FrameCodec()
+    // Frame with unknown class/method IDs
+    var buffer = Data([
+      0x01,  // method frame
+      0x00, 0x01,  // channel 1
+      0x00, 0x00, 0x00, 0x04,  // size 4
+      0xFF, 0xFF,  // class 65535
+      0xFF, 0xFF,  // method 65535
+      0xCE,  // frame end
+    ])
+    #expect(throws: AMQPProtocolError.self) {
+      _ = try codec.decode(from: &buffer)
     }
+  }
 
-    @Test("Unknown method throws error")
-    func unknownMethod() {
-        let codec = FrameCodec()
-        // Frame with unknown class/method IDs
-        var buffer = Data([
-            0x01,  // method frame
-            0x00, 0x01,  // channel 1
-            0x00, 0x00, 0x00, 0x04,  // size 4
-            0xFF, 0xFF,  // class 65535
-            0xFF, 0xFF,  // method 65535
-            0xCE  // frame end
-        ])
-        #expect(throws: AMQPProtocolError.self) {
-            _ = try codec.decode(from: &buffer)
-        }
+  @Test("Multiple frames in buffer")
+  func multipleFrames() throws {
+    let codec = FrameCodec()
+    let frame1 = Frame.heartbeat
+    let frame2 = Frame.method(channelID: 1, method: .channelCloseOk)
+
+    var buffer = try codec.encode(frame1)
+    buffer.append(try codec.encode(frame2))
+
+    let decoded1 = try codec.decode(from: &buffer)
+    let decoded2 = try codec.decode(from: &buffer)
+
+    #expect(decoded1 == frame1)
+    #expect(decoded2 == frame2)
+    #expect(buffer.isEmpty)
+  }
+
+  @Test("Maximum channel ID")
+  func maxChannelID() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: UInt16.max, method: .channelCloseOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
+
+    if case .method(let ch, _) = decoded {
+      #expect(ch == UInt16.max)
+    } else {
+      Issue.record("Expected method frame")
     }
+  }
 
-    @Test("Multiple frames in buffer")
-    func multipleFrames() throws {
-        let codec = FrameCodec()
-        let frame1 = Frame.heartbeat
-        let frame2 = Frame.method(channelID: 1, method: .channelCloseOk)
+  @Test("Channel ID zero for connection methods")
+  func channelZero() throws {
+    let codec = FrameCodec()
+    let frame = Frame.method(channelID: 0, method: .connectionCloseOk)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        var buffer = try codec.encode(frame1)
-        buffer.append(try codec.encode(frame2))
-
-        let decoded1 = try codec.decode(from: &buffer)
-        let decoded2 = try codec.decode(from: &buffer)
-
-        #expect(decoded1 == frame1)
-        #expect(decoded2 == frame2)
-        #expect(buffer.isEmpty)
+    if case .method(let ch, _) = decoded {
+      #expect(ch == 0)
+    } else {
+      Issue.record("Expected method frame")
     }
+  }
 
-    @Test("Maximum channel ID")
-    func maxChannelID() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: UInt16.max, method: .channelCloseOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Body frame at exact frame max minus overhead")
+  func bodyFrameExactMax() throws {
+    let frameMax: UInt32 = 100
+    let codec = FrameCodec(maxFrameSize: frameMax)
+    // Frame overhead: type(1) + channel(2) + size(4) + end(1) = 8 bytes
+    let payload = Data(repeating: 0xAB, count: Int(frameMax) - 8)
+    let frame = Frame.body(channelID: 1, payload: payload)
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(let ch, _) = decoded {
-            #expect(ch == UInt16.max)
-        } else {
-            Issue.record("Expected method frame")
-        }
+    if case .body(_, let decodedPayload) = decoded {
+      #expect(decodedPayload == payload)
+    } else {
+      Issue.record("Expected body frame")
     }
+  }
 
-    @Test("Channel ID zero for connection methods")
-    func channelZero() throws {
-        let codec = FrameCodec()
-        let frame = Frame.method(channelID: 0, method: .connectionCloseOk)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
+  @Test("Large delivery tag")
+  func largeDeliveryTag() throws {
+    let codec = FrameCodec()
+    let deliver = BasicDeliver(
+      consumerTag: "ctag",
+      deliveryTag: UInt64.max,
+      redelivered: false,
+      exchange: "ex",
+      routingKey: "key"
+    )
+    let frame = Frame.method(channelID: 1, method: .basicDeliver(deliver))
+    var data = try codec.encode(frame)
+    let decoded = try codec.decode(from: &data)
 
-        if case .method(let ch, _) = decoded {
-            #expect(ch == 0)
-        } else {
-            Issue.record("Expected method frame")
-        }
+    if case .method(_, .basicDeliver(let d)) = decoded {
+      #expect(d.deliveryTag == UInt64.max)
+    } else {
+      Issue.record("Expected basicDeliver")
     }
-
-    @Test("Body frame at exact frame max minus overhead")
-    func bodyFrameExactMax() throws {
-        let frameMax: UInt32 = 100
-        let codec = FrameCodec(maxFrameSize: frameMax)
-        // Frame overhead: type(1) + channel(2) + size(4) + end(1) = 8 bytes
-        let payload = Data(repeating: 0xAB, count: Int(frameMax) - 8)
-        let frame = Frame.body(channelID: 1, payload: payload)
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-
-        if case .body(_, let decodedPayload) = decoded {
-            #expect(decodedPayload == payload)
-        } else {
-            Issue.record("Expected body frame")
-        }
-    }
-
-    @Test("Large delivery tag")
-    func largeDeliveryTag() throws {
-        let codec = FrameCodec()
-        let deliver = BasicDeliver(
-            consumerTag: "ctag",
-            deliveryTag: UInt64.max,
-            redelivered: false,
-            exchange: "ex",
-            routingKey: "key"
-        )
-        let frame = Frame.method(channelID: 1, method: .basicDeliver(deliver))
-        var data = try codec.encode(frame)
-        let decoded = try codec.decode(from: &data)
-
-        if case .method(_, .basicDeliver(let d)) = decoded {
-            #expect(d.deliveryTag == UInt64.max)
-        } else {
-            Issue.record("Expected basicDeliver")
-        }
-    }
+  }
 }
 
 @Suite("Method Properties Tests")
 struct MethodPropertiesTests {
-    @Test("Method IDs are correct")
-    func methodIDs() {
-        #expect(Method.connectionStart(ConnectionStart()).methodID == MethodID(classID: 10, methodID: 10))
-        #expect(Method.channelOpen(ChannelOpen()).methodID == MethodID(classID: 20, methodID: 10))
-        #expect(Method.exchangeDeclare(ExchangeDeclare(exchange: "")).methodID == MethodID(classID: 40, methodID: 10))
-        #expect(Method.queueDeclare(QueueDeclare()).methodID == MethodID(classID: 50, methodID: 10))
-        #expect(Method.basicPublish(BasicPublish(routingKey: "")).methodID == MethodID(classID: 60, methodID: 40))
-        #expect(Method.txSelect.methodID == MethodID(classID: 90, methodID: 10))
-        #expect(Method.confirmSelect(ConfirmSelect()).methodID == MethodID(classID: 85, methodID: 10))
-    }
+  @Test("Method IDs are correct")
+  func methodIDs() {
+    #expect(
+      Method.connectionStart(ConnectionStart()).methodID == MethodID(classID: 10, methodID: 10))
+    #expect(Method.channelOpen(ChannelOpen()).methodID == MethodID(classID: 20, methodID: 10))
+    #expect(
+      Method.exchangeDeclare(ExchangeDeclare(exchange: "")).methodID
+        == MethodID(classID: 40, methodID: 10))
+    #expect(Method.queueDeclare(QueueDeclare()).methodID == MethodID(classID: 50, methodID: 10))
+    #expect(
+      Method.basicPublish(BasicPublish(routingKey: "")).methodID
+        == MethodID(classID: 60, methodID: 40))
+    #expect(Method.txSelect.methodID == MethodID(classID: 90, methodID: 10))
+    #expect(Method.confirmSelect(ConfirmSelect()).methodID == MethodID(classID: 85, methodID: 10))
+  }
 
-    @Test("Methods with content")
-    func methodsWithContent() {
-        #expect(Method.basicPublish(BasicPublish(routingKey: "")).hasContent == true)
-        #expect(Method.basicReturn(BasicReturn(replyCode: 0, replyText: "", exchange: "", routingKey: "")).hasContent == true)
-        #expect(Method.basicDeliver(BasicDeliver(consumerTag: "", deliveryTag: 0, redelivered: false, exchange: "", routingKey: "")).hasContent == true)
-        #expect(Method.basicGetOk(BasicGetOk(deliveryTag: 0, redelivered: false, exchange: "", routingKey: "", messageCount: 0)).hasContent == true)
-        #expect(Method.basicAck(BasicAck(deliveryTag: 0)).hasContent == false)
-        #expect(Method.queueDeclare(QueueDeclare()).hasContent == false)
-    }
+  @Test("Methods with content")
+  func methodsWithContent() {
+    #expect(Method.basicPublish(BasicPublish(routingKey: "")).hasContent == true)
+    #expect(
+      Method.basicReturn(BasicReturn(replyCode: 0, replyText: "", exchange: "", routingKey: ""))
+        .hasContent == true)
+    #expect(
+      Method.basicDeliver(
+        BasicDeliver(
+          consumerTag: "", deliveryTag: 0, redelivered: false, exchange: "", routingKey: "")
+      ).hasContent == true)
+    #expect(
+      Method.basicGetOk(
+        BasicGetOk(
+          deliveryTag: 0, redelivered: false, exchange: "", routingKey: "", messageCount: 0)
+      ).hasContent == true)
+    #expect(Method.basicAck(BasicAck(deliveryTag: 0)).hasContent == false)
+    #expect(Method.queueDeclare(QueueDeclare()).hasContent == false)
+  }
 
-    @Test("Methods expecting response")
-    func methodsExpectingResponse() {
-        #expect(Method.connectionOpen(ConnectionOpen()).expectsResponse == true)
-        #expect(Method.channelOpen(ChannelOpen()).expectsResponse == true)
-        #expect(Method.queueDeclare(QueueDeclare()).expectsResponse == true)
-        #expect(Method.basicAck(BasicAck(deliveryTag: 0)).expectsResponse == false)
-        #expect(Method.connectionCloseOk.expectsResponse == false)
-    }
+  @Test("Methods expecting response")
+  func methodsExpectingResponse() {
+    #expect(Method.connectionOpen(ConnectionOpen()).expectsResponse == true)
+    #expect(Method.channelOpen(ChannelOpen()).expectsResponse == true)
+    #expect(Method.queueDeclare(QueueDeclare()).expectsResponse == true)
+    #expect(Method.basicAck(BasicAck(deliveryTag: 0)).expectsResponse == false)
+    #expect(Method.connectionCloseOk.expectsResponse == false)
+  }
 }
 
 @Suite("BasicProperties Tests")
 struct BasicPropertiesTests {
-    @Test("Property flags are computed correctly")
-    func propertyFlags() {
-        let props = BasicProperties(
-            contentType: "application/json",
-            deliveryMode: .persistent
-        )
-        let flags = props.propertyFlags
-        #expect(flags.contains(.contentType))
-        #expect(flags.contains(.deliveryMode))
-        #expect(!flags.contains(.headers))
-        #expect(!flags.contains(.priority))
-    }
+  @Test("Property flags are computed correctly")
+  func propertyFlags() {
+    let props = BasicProperties(
+      contentType: "application/json",
+      deliveryMode: .persistent
+    )
+    let flags = props.propertyFlags
+    #expect(flags.contains(.contentType))
+    #expect(flags.contains(.deliveryMode))
+    #expect(!flags.contains(.headers))
+    #expect(!flags.contains(.priority))
+  }
 
-    @Test("Persistent static property")
-    func persistentProperty() {
-        let props = BasicProperties.persistent.withContentType("text/plain")
-        #expect(props.deliveryMode == DeliveryMode.persistent)
-        #expect(props.contentType == "text/plain")
-    }
+  @Test("Persistent static property")
+  func persistentProperty() {
+    let props = BasicProperties.persistent.withContentType("text/plain")
+    #expect(props.deliveryMode == DeliveryMode.persistent)
+    #expect(props.contentType == "text/plain")
+  }
 
-    @Test("Transient static property")
-    func transientProperty() {
-        let props = BasicProperties.transient
-        #expect(props.deliveryMode == DeliveryMode.transient)
-    }
+  @Test("Transient static property")
+  func transientProperty() {
+    let props = BasicProperties.transient
+    #expect(props.deliveryMode == DeliveryMode.transient)
+  }
 
-    @Test("Fluent builders")
-    func fluentBuilders() {
-        let props = BasicProperties()
-            .withContentType("application/json")
-            .withCorrelationId("abc123")
-            .withPriority(5)
-            .withDeliveryMode(.persistent)
+  @Test("Fluent builders")
+  func fluentBuilders() {
+    let props = BasicProperties()
+      .withContentType("application/json")
+      .withCorrelationId("abc123")
+      .withPriority(5)
+      .withDeliveryMode(.persistent)
 
-        #expect(props.contentType == "application/json")
-        #expect(props.correlationId == "abc123")
-        #expect(props.priority == 5)
-        #expect(props.deliveryMode == .persistent)
-    }
+    #expect(props.contentType == "application/json")
+    #expect(props.correlationId == "abc123")
+    #expect(props.priority == 5)
+    #expect(props.deliveryMode == .persistent)
+  }
 
-    @Test("Expiration from Duration")
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-    func expirationFromDuration() {
-        let props = BasicProperties().withExpiration(.seconds(60))
-        #expect(props.expiration == "60000")
-    }
+  @Test("Expiration from Duration")
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  func expirationFromDuration() {
+    let props = BasicProperties().withExpiration(.seconds(60))
+    #expect(props.expiration == "60000")
+  }
 
-    @Test("Expiration from milliseconds")
-    func expirationFromMilliseconds() {
-        let props = BasicProperties().withExpiration(milliseconds: 5000)
-        #expect(props.expiration == "5000")
+  @Test("Expiration from milliseconds")
+  func expirationFromMilliseconds() {
+    let props = BasicProperties().withExpiration(milliseconds: 5000)
+    #expect(props.expiration == "5000")
 
-        let props2 = BasicProperties().withExpiration(milliseconds: 0)
-        #expect(props2.expiration == "0")
-    }
+    let props2 = BasicProperties().withExpiration(milliseconds: 0)
+    #expect(props2.expiration == "0")
+  }
 }

--- a/Tests/AMQPProtocolTests/TableEncodingTests.swift
+++ b/Tests/AMQPProtocolTests/TableEncodingTests.swift
@@ -10,538 +10,539 @@
 
 import Foundation
 import Testing
+
 @testable import AMQPProtocol
 
 @Suite("FieldValue Type Tests")
 struct FieldValueTypeTests {
-    @Test("Boolean field value")
-    func booleanValue() throws {
-        let values: [FieldValue] = [.boolean(true), .boolean(false)]
-        for value in values {
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("Boolean field value")
+  func booleanValue() throws {
+    let values: [FieldValue] = [.boolean(true), .boolean(false)]
+    for value in values {
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("Int8 field value")
-    func int8Value() throws {
-        let testValues: [Int8] = [0, 1, -1, Int8.min, Int8.max]
-        for v in testValues {
-            let value = FieldValue.int8(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("Int8 field value")
+  func int8Value() throws {
+    let testValues: [Int8] = [0, 1, -1, Int8.min, Int8.max]
+    for v in testValues {
+      let value = FieldValue.int8(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("UInt8 field value")
-    func uint8Value() throws {
-        let testValues: [UInt8] = [0, 1, UInt8.max]
-        for v in testValues {
-            let value = FieldValue.uint8(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("UInt8 field value")
+  func uint8Value() throws {
+    let testValues: [UInt8] = [0, 1, UInt8.max]
+    for v in testValues {
+      let value = FieldValue.uint8(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("Int16 field value")
-    func int16Value() throws {
-        let testValues: [Int16] = [0, 1, -1, Int16.min, Int16.max]
-        for v in testValues {
-            let value = FieldValue.int16(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("Int16 field value")
+  func int16Value() throws {
+    let testValues: [Int16] = [0, 1, -1, Int16.min, Int16.max]
+    for v in testValues {
+      let value = FieldValue.int16(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("UInt16 field value")
-    func uint16Value() throws {
-        let testValues: [UInt16] = [0, 1, UInt16.max]
-        for v in testValues {
-            let value = FieldValue.uint16(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("UInt16 field value")
+  func uint16Value() throws {
+    let testValues: [UInt16] = [0, 1, UInt16.max]
+    for v in testValues {
+      let value = FieldValue.uint16(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("Int32 field value")
-    func int32Value() throws {
-        let testValues: [Int32] = [0, 1, -1, Int32.min, Int32.max]
-        for v in testValues {
-            let value = FieldValue.int32(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("Int32 field value")
+  func int32Value() throws {
+    let testValues: [Int32] = [0, 1, -1, Int32.min, Int32.max]
+    for v in testValues {
+      let value = FieldValue.int32(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("UInt32 field value")
-    func uint32Value() throws {
-        let testValues: [UInt32] = [0, 1, UInt32.max]
-        for v in testValues {
-            let value = FieldValue.uint32(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("UInt32 field value")
+  func uint32Value() throws {
+    let testValues: [UInt32] = [0, 1, UInt32.max]
+    for v in testValues {
+      let value = FieldValue.uint32(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("Int64 field value")
-    func int64Value() throws {
-        let testValues: [Int64] = [0, 1, -1, Int64.min, Int64.max]
-        for v in testValues {
-            let value = FieldValue.int64(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("Int64 field value")
+  func int64Value() throws {
+    let testValues: [Int64] = [0, 1, -1, Int64.min, Int64.max]
+    for v in testValues {
+      let value = FieldValue.int64(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("Float field value")
-    func floatValue() throws {
-        let testValues: [Float] = [0.0, 1.0, -1.0, Float.pi, Float.greatestFiniteMagnitude]
-        for v in testValues {
-            let value = FieldValue.float(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("Float field value")
+  func floatValue() throws {
+    let testValues: [Float] = [0.0, 1.0, -1.0, Float.pi, Float.greatestFiniteMagnitude]
+    for v in testValues {
+      let value = FieldValue.float(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("Double field value")
-    func doubleValue() throws {
-        let testValues: [Double] = [0.0, 1.0, -1.0, Double.pi, Double.greatestFiniteMagnitude]
-        for v in testValues {
-            let value = FieldValue.double(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("Double field value")
+  func doubleValue() throws {
+    let testValues: [Double] = [0.0, 1.0, -1.0, Double.pi, Double.greatestFiniteMagnitude]
+    for v in testValues {
+      let value = FieldValue.double(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("Decimal field value")
-    func decimalValue() throws {
-        let value = FieldValue.decimal(scale: 2, value: 12345)
-        var encoder = WireEncoder()
-        try value.encode(to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try FieldValue.decode(from: &decoder)
-        #expect(decoded == value)
-    }
+  @Test("Decimal field value")
+  func decimalValue() throws {
+    let value = FieldValue.decimal(scale: 2, value: 12345)
+    var encoder = WireEncoder()
+    try value.encode(to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try FieldValue.decode(from: &decoder)
+    #expect(decoded == value)
+  }
 
-    @Test("String field value")
-    func stringValue() throws {
-        let testValues = ["", "hello", "test with spaces", "unicode: 日本語 🎉"]
-        for v in testValues {
-            let value = FieldValue.string(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("String field value")
+  func stringValue() throws {
+    let testValues = ["", "hello", "test with spaces", "unicode: 日本語 🎉"]
+    for v in testValues {
+      let value = FieldValue.string(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("Bytes field value")
-    func bytesValue() throws {
-        let testValues = [Data(), Data([0x01, 0x02, 0x03]), Data(repeating: 0xAB, count: 100)]
-        for v in testValues {
-            let value = FieldValue.bytes(v)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("Bytes field value")
+  func bytesValue() throws {
+    let testValues = [Data(), Data([0x01, 0x02, 0x03]), Data(repeating: 0xAB, count: 100)]
+    for v in testValues {
+      let value = FieldValue.bytes(v)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("Timestamp field value")
-    func timestampValue() throws {
-        let dates = [
-            Date(timeIntervalSince1970: 0),
-            Date(timeIntervalSince1970: 1234567890),
-            Date()
-        ]
-        for date in dates {
-            // Timestamps are stored as whole seconds
-            let truncatedDate = Date(timeIntervalSince1970: floor(date.timeIntervalSince1970))
-            let value = FieldValue.timestamp(truncatedDate)
-            var encoder = WireEncoder()
-            try value.encode(to: &encoder)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try FieldValue.decode(from: &decoder)
-            #expect(decoded == value)
-        }
+  @Test("Timestamp field value")
+  func timestampValue() throws {
+    let dates = [
+      Date(timeIntervalSince1970: 0),
+      Date(timeIntervalSince1970: 1_234_567_890),
+      Date(),
+    ]
+    for date in dates {
+      // Timestamps are stored as whole seconds
+      let truncatedDate = Date(timeIntervalSince1970: floor(date.timeIntervalSince1970))
+      let value = FieldValue.timestamp(truncatedDate)
+      var encoder = WireEncoder()
+      try value.encode(to: &encoder)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try FieldValue.decode(from: &decoder)
+      #expect(decoded == value)
     }
+  }
 
-    @Test("Void field value")
-    func voidValue() throws {
-        let value = FieldValue.void
-        var encoder = WireEncoder()
-        try value.encode(to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try FieldValue.decode(from: &decoder)
-        #expect(decoded == value)
-    }
+  @Test("Void field value")
+  func voidValue() throws {
+    let value = FieldValue.void
+    var encoder = WireEncoder()
+    try value.encode(to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try FieldValue.decode(from: &decoder)
+    #expect(decoded == value)
+  }
 
-    @Test("Array field value")
-    func arrayValue() throws {
-        let value = FieldValue.array([
-            .string("hello"),
-            .int32(42),
-            .boolean(true)
-        ])
-        var encoder = WireEncoder()
-        try value.encode(to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try FieldValue.decode(from: &decoder)
-        #expect(decoded == value)
-    }
+  @Test("Array field value")
+  func arrayValue() throws {
+    let value = FieldValue.array([
+      .string("hello"),
+      .int32(42),
+      .boolean(true),
+    ])
+    var encoder = WireEncoder()
+    try value.encode(to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try FieldValue.decode(from: &decoder)
+    #expect(decoded == value)
+  }
 
-    @Test("Nested array field value")
-    func nestedArrayValue() throws {
-        let value = FieldValue.array([
-            .array([.string("nested"), .int32(1)]),
-            .string("outer")
-        ])
-        var encoder = WireEncoder()
-        try value.encode(to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try FieldValue.decode(from: &decoder)
-        #expect(decoded == value)
-    }
+  @Test("Nested array field value")
+  func nestedArrayValue() throws {
+    let value = FieldValue.array([
+      .array([.string("nested"), .int32(1)]),
+      .string("outer"),
+    ])
+    var encoder = WireEncoder()
+    try value.encode(to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try FieldValue.decode(from: &decoder)
+    #expect(decoded == value)
+  }
 }
 
 @Suite("Table Encoding Tests")
 struct TableEncodingTests {
-    @Test("Empty table")
-    func emptyTable() throws {
-        let table: Table = [:]
-        let encoded = try encodeTable(table)
-        let decoded = try decodeTable(from: encoded)
-        #expect(decoded.isEmpty)
+  @Test("Empty table")
+  func emptyTable() throws {
+    let table: Table = [:]
+    let encoded = try encodeTable(table)
+    let decoded = try decodeTable(from: encoded)
+    #expect(decoded.isEmpty)
+  }
+
+  @Test("Simple table with string value")
+  func simpleStringTable() throws {
+    let table: Table = ["key": .string("value")]
+    var encoder = WireEncoder()
+    try encodeTable(table, to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try decodeTable(from: &decoder)
+    #expect(decoded["key"] == .string("value"))
+  }
+
+  @Test("Table with multiple value types")
+  func mixedTypeTable() throws {
+    let table: Table = [
+      "string": .string("hello"),
+      "int": .int32(42),
+      "bool": .boolean(true),
+      "double": .double(3.14),
+    ]
+    var encoder = WireEncoder()
+    try encodeTable(table, to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try decodeTable(from: &decoder)
+    #expect(decoded["string"] == .string("hello"))
+    #expect(decoded["int"] == .int32(42))
+    #expect(decoded["bool"] == .boolean(true))
+    #expect(decoded["double"] == .double(3.14))
+  }
+
+  @Test("Nested table")
+  func nestedTable() throws {
+    let inner: Table = ["inner_key": .string("inner_value")]
+    let outer: Table = ["nested": .table(inner)]
+    var encoder = WireEncoder()
+    try encodeTable(outer, to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try decodeTable(from: &decoder)
+
+    if case .table(let nested) = decoded["nested"] {
+      #expect(nested["inner_key"] == .string("inner_value"))
+    } else {
+      Issue.record("Expected nested table")
     }
+  }
 
-    @Test("Simple table with string value")
-    func simpleStringTable() throws {
-        let table: Table = ["key": .string("value")]
-        var encoder = WireEncoder()
-        try encodeTable(table, to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try decodeTable(from: &decoder)
-        #expect(decoded["key"] == .string("value"))
+  @Test("Table with array value")
+  func tableWithArray() throws {
+    let table: Table = [
+      "array": .array([.string("a"), .string("b"), .string("c")])
+    ]
+    var encoder = WireEncoder()
+    try encodeTable(table, to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try decodeTable(from: &decoder)
+
+    if case .array(let arr) = decoded["array"] {
+      #expect(arr.count == 3)
+      #expect(arr[0] == .string("a"))
+    } else {
+      Issue.record("Expected array")
     }
+  }
 
-    @Test("Table with multiple value types")
-    func mixedTypeTable() throws {
-        let table: Table = [
-            "string": .string("hello"),
-            "int": .int32(42),
-            "bool": .boolean(true),
-            "double": .double(3.14)
-        ]
-        var encoder = WireEncoder()
-        try encodeTable(table, to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try decodeTable(from: &decoder)
-        #expect(decoded["string"] == .string("hello"))
-        #expect(decoded["int"] == .int32(42))
-        #expect(decoded["bool"] == .boolean(true))
-        #expect(decoded["double"] == .double(3.14))
-    }
+  @Test("Table roundtrip preserves all types")
+  func tableRoundtrip() throws {
+    let table: Table = [
+      "bool": .boolean(true),
+      "int8": .int8(-42),
+      "uint8": .uint8(200),
+      "int16": .int16(-1000),
+      "uint16": .uint16(60000),
+      "int32": .int32(-100000),
+      "uint32": .uint32(3_000_000_000),
+      "int64": .int64(-9_000_000_000_000),
+      "float": .float(3.14),
+      "double": .double(2.71828),
+      "decimal": .decimal(scale: 2, value: 12345),
+      "string": .string("test"),
+      "bytes": .bytes(Data([0x01, 0x02, 0x03])),
+      "void": .void,
+      "timestamp": .timestamp(Date(timeIntervalSince1970: 1_234_567_890)),
+      "array": .array([.string("a"), .int32(1)]),
+      "nested": .table(["inner": .string("value")]),
+    ]
+    var encoder = WireEncoder()
+    try encodeTable(table, to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try decodeTable(from: &decoder)
 
-    @Test("Nested table")
-    func nestedTable() throws {
-        let inner: Table = ["inner_key": .string("inner_value")]
-        let outer: Table = ["nested": .table(inner)]
-        var encoder = WireEncoder()
-        try encodeTable(outer, to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try decodeTable(from: &decoder)
-
-        if case .table(let nested) = decoded["nested"] {
-            #expect(nested["inner_key"] == .string("inner_value"))
-        } else {
-            Issue.record("Expected nested table")
-        }
-    }
-
-    @Test("Table with array value")
-    func tableWithArray() throws {
-        let table: Table = [
-            "array": .array([.string("a"), .string("b"), .string("c")])
-        ]
-        var encoder = WireEncoder()
-        try encodeTable(table, to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try decodeTable(from: &decoder)
-
-        if case .array(let arr) = decoded["array"] {
-            #expect(arr.count == 3)
-            #expect(arr[0] == .string("a"))
-        } else {
-            Issue.record("Expected array")
-        }
-    }
-
-    @Test("Table roundtrip preserves all types")
-    func tableRoundtrip() throws {
-        let table: Table = [
-            "bool": .boolean(true),
-            "int8": .int8(-42),
-            "uint8": .uint8(200),
-            "int16": .int16(-1000),
-            "uint16": .uint16(60000),
-            "int32": .int32(-100000),
-            "uint32": .uint32(3000000000),
-            "int64": .int64(-9000000000000),
-            "float": .float(3.14),
-            "double": .double(2.71828),
-            "decimal": .decimal(scale: 2, value: 12345),
-            "string": .string("test"),
-            "bytes": .bytes(Data([0x01, 0x02, 0x03])),
-            "void": .void,
-            "timestamp": .timestamp(Date(timeIntervalSince1970: 1234567890)),
-            "array": .array([.string("a"), .int32(1)]),
-            "nested": .table(["inner": .string("value")])
-        ]
-        var encoder = WireEncoder()
-        try encodeTable(table, to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try decodeTable(from: &decoder)
-
-        #expect(decoded["bool"] == table["bool"])
-        #expect(decoded["int8"] == table["int8"])
-        #expect(decoded["uint8"] == table["uint8"])
-        #expect(decoded["int16"] == table["int16"])
-        #expect(decoded["uint16"] == table["uint16"])
-        #expect(decoded["int32"] == table["int32"])
-        #expect(decoded["uint32"] == table["uint32"])
-        #expect(decoded["int64"] == table["int64"])
-        #expect(decoded["float"] == table["float"])
-        #expect(decoded["double"] == table["double"])
-        #expect(decoded["decimal"] == table["decimal"])
-        #expect(decoded["string"] == table["string"])
-        #expect(decoded["bytes"] == table["bytes"])
-        #expect(decoded["void"] == table["void"])
-        #expect(decoded["timestamp"] == table["timestamp"])
-        #expect(decoded["array"] == table["array"])
-        #expect(decoded["nested"] == table["nested"])
-    }
+    #expect(decoded["bool"] == table["bool"])
+    #expect(decoded["int8"] == table["int8"])
+    #expect(decoded["uint8"] == table["uint8"])
+    #expect(decoded["int16"] == table["int16"])
+    #expect(decoded["uint16"] == table["uint16"])
+    #expect(decoded["int32"] == table["int32"])
+    #expect(decoded["uint32"] == table["uint32"])
+    #expect(decoded["int64"] == table["int64"])
+    #expect(decoded["float"] == table["float"])
+    #expect(decoded["double"] == table["double"])
+    #expect(decoded["decimal"] == table["decimal"])
+    #expect(decoded["string"] == table["string"])
+    #expect(decoded["bytes"] == table["bytes"])
+    #expect(decoded["void"] == table["void"])
+    #expect(decoded["timestamp"] == table["timestamp"])
+    #expect(decoded["array"] == table["array"])
+    #expect(decoded["nested"] == table["nested"])
+  }
 }
 
 @Suite("FieldValue Literal Conformance Tests")
 struct FieldValueLiteralTests {
-    @Test("ExpressibleByBooleanLiteral")
-    func booleanLiteral() {
-        let value: FieldValue = true
-        #expect(value == .boolean(true))
-        let value2: FieldValue = false
-        #expect(value2 == .boolean(false))
-    }
+  @Test("ExpressibleByBooleanLiteral")
+  func booleanLiteral() {
+    let value: FieldValue = true
+    #expect(value == .boolean(true))
+    let value2: FieldValue = false
+    #expect(value2 == .boolean(false))
+  }
 
-    @Test("ExpressibleByIntegerLiteral")
-    func integerLiteral() {
-        let value: FieldValue = 42
-        #expect(value == .int64(42))
-    }
+  @Test("ExpressibleByIntegerLiteral")
+  func integerLiteral() {
+    let value: FieldValue = 42
+    #expect(value == .int64(42))
+  }
 
-    @Test("ExpressibleByFloatLiteral")
-    func floatLiteral() {
-        let value: FieldValue = 3.14
-        #expect(value == .double(3.14))
-    }
+  @Test("ExpressibleByFloatLiteral")
+  func floatLiteral() {
+    let value: FieldValue = 3.14
+    #expect(value == .double(3.14))
+  }
 
-    @Test("ExpressibleByStringLiteral")
-    func stringLiteral() {
-        let value: FieldValue = "hello"
-        #expect(value == .string("hello"))
-    }
+  @Test("ExpressibleByStringLiteral")
+  func stringLiteral() {
+    let value: FieldValue = "hello"
+    #expect(value == .string("hello"))
+  }
 
-    @Test("ExpressibleByArrayLiteral")
-    func arrayLiteral() {
-        let value: FieldValue = [1, 2, 3]
-        #expect(value == .array([.int64(1), .int64(2), .int64(3)]))
-    }
+  @Test("ExpressibleByArrayLiteral")
+  func arrayLiteral() {
+    let value: FieldValue = [1, 2, 3]
+    #expect(value == .array([.int64(1), .int64(2), .int64(3)]))
+  }
 
-    @Test("ExpressibleByDictionaryLiteral")
-    func dictionaryLiteral() {
-        let value: FieldValue = ["key": "value"]
-        if case .table(let table) = value {
-            #expect(table["key"] == .string("value"))
-        } else {
-            Issue.record("Expected table")
-        }
+  @Test("ExpressibleByDictionaryLiteral")
+  func dictionaryLiteral() {
+    let value: FieldValue = ["key": "value"]
+    if case .table(let table) = value {
+      #expect(table["key"] == .string("value"))
+    } else {
+      Issue.record("Expected table")
     }
+  }
 
-    @Test("ExpressibleByNilLiteral")
-    func nilLiteral() {
-        let value: FieldValue = nil
-        #expect(value == .void)
-    }
+  @Test("ExpressibleByNilLiteral")
+  func nilLiteral() {
+    let value: FieldValue = nil
+    #expect(value == .void)
+  }
 }
 
 @Suite("FieldValue Accessor Tests")
 struct FieldValueAccessorTests {
-    @Test("boolValue accessor")
-    func boolAccessor() {
-        #expect(FieldValue.boolean(true).boolValue == true)
-        #expect(FieldValue.string("test").boolValue == nil)
-    }
+  @Test("boolValue accessor")
+  func boolAccessor() {
+    #expect(FieldValue.boolean(true).boolValue == true)
+    #expect(FieldValue.string("test").boolValue == nil)
+  }
 
-    @Test("intValue accessor coerces integer types")
-    func intAccessor() {
-        #expect(FieldValue.int8(42).intValue == 42)
-        #expect(FieldValue.uint8(200).intValue == 200)
-        #expect(FieldValue.int16(-100).intValue == -100)
-        #expect(FieldValue.uint16(60000).intValue == 60000)
-        #expect(FieldValue.int32(-100000).intValue == -100000)
-        #expect(FieldValue.uint32(3000000000).intValue == 3000000000)
-        #expect(FieldValue.int64(-9000000000000).intValue == -9000000000000)
-        #expect(FieldValue.string("test").intValue == nil)
-    }
+  @Test("intValue accessor coerces integer types")
+  func intAccessor() {
+    #expect(FieldValue.int8(42).intValue == 42)
+    #expect(FieldValue.uint8(200).intValue == 200)
+    #expect(FieldValue.int16(-100).intValue == -100)
+    #expect(FieldValue.uint16(60000).intValue == 60000)
+    #expect(FieldValue.int32(-100000).intValue == -100000)
+    #expect(FieldValue.uint32(3_000_000_000).intValue == 3_000_000_000)
+    #expect(FieldValue.int64(-9_000_000_000_000).intValue == -9_000_000_000_000)
+    #expect(FieldValue.string("test").intValue == nil)
+  }
 
-    @Test("doubleValue accessor")
-    func doubleAccessor() {
-        #expect(FieldValue.float(3.14).doubleValue! == Double(Float(3.14)))
-        #expect(FieldValue.double(2.718).doubleValue == 2.718)
-        #expect(FieldValue.string("test").doubleValue == nil)
-    }
+  @Test("doubleValue accessor")
+  func doubleAccessor() {
+    #expect(FieldValue.float(3.14).doubleValue! == Double(Float(3.14)))
+    #expect(FieldValue.double(2.718).doubleValue == 2.718)
+    #expect(FieldValue.string("test").doubleValue == nil)
+  }
 
-    @Test("stringValue accessor")
-    func stringAccessor() {
-        #expect(FieldValue.string("hello").stringValue == "hello")
-        #expect(FieldValue.int32(42).stringValue == nil)
-    }
+  @Test("stringValue accessor")
+  func stringAccessor() {
+    #expect(FieldValue.string("hello").stringValue == "hello")
+    #expect(FieldValue.int32(42).stringValue == nil)
+  }
 
-    @Test("dataValue accessor")
-    func dataAccessor() {
-        let data = Data([0x01, 0x02, 0x03])
-        #expect(FieldValue.bytes(data).dataValue == data)
-        #expect(FieldValue.string("test").dataValue == nil)
-    }
+  @Test("dataValue accessor")
+  func dataAccessor() {
+    let data = Data([0x01, 0x02, 0x03])
+    #expect(FieldValue.bytes(data).dataValue == data)
+    #expect(FieldValue.string("test").dataValue == nil)
+  }
 
-    @Test("dateValue accessor")
-    func dateAccessor() {
-        let date = Date(timeIntervalSince1970: 1234567890)
-        #expect(FieldValue.timestamp(date).dateValue == date)
-        #expect(FieldValue.string("test").dateValue == nil)
-    }
+  @Test("dateValue accessor")
+  func dateAccessor() {
+    let date = Date(timeIntervalSince1970: 1_234_567_890)
+    #expect(FieldValue.timestamp(date).dateValue == date)
+    #expect(FieldValue.string("test").dateValue == nil)
+  }
 
-    @Test("arrayValue accessor")
-    func arrayAccessor() {
-        let arr: [FieldValue] = [.string("a"), .int32(1)]
-        #expect(FieldValue.array(arr).arrayValue == arr)
-        #expect(FieldValue.string("test").arrayValue == nil)
-    }
+  @Test("arrayValue accessor")
+  func arrayAccessor() {
+    let arr: [FieldValue] = [.string("a"), .int32(1)]
+    #expect(FieldValue.array(arr).arrayValue == arr)
+    #expect(FieldValue.string("test").arrayValue == nil)
+  }
 
-    @Test("tableValue accessor")
-    func tableAccessor() {
-        let table: Table = ["key": .string("value")]
-        #expect(FieldValue.table(table).tableValue == table)
-        #expect(FieldValue.string("test").tableValue == nil)
-    }
+  @Test("tableValue accessor")
+  func tableAccessor() {
+    let table: Table = ["key": .string("value")]
+    #expect(FieldValue.table(table).tableValue == table)
+    #expect(FieldValue.string("test").tableValue == nil)
+  }
 
-    @Test("isVoid accessor")
-    func voidAccessor() {
-        #expect(FieldValue.void.isVoid == true)
-        #expect(FieldValue.string("test").isVoid == false)
-    }
+  @Test("isVoid accessor")
+  func voidAccessor() {
+    #expect(FieldValue.void.isVoid == true)
+    #expect(FieldValue.string("test").isVoid == false)
+  }
 }
 
 @Suite("Unknown Field Type Error Tests")
 struct FieldTypeErrorTests {
-    @Test("Unknown field type throws error")
-    func unknownFieldType() {
-        var decoder = WireDecoder(Data([0xFF, 0x00]))
-        #expect(throws: WireFormatError.self) {
-            _ = try FieldValue.decode(from: &decoder)
-        }
+  @Test("Unknown field type throws error")
+  func unknownFieldType() {
+    var decoder = WireDecoder(Data([0xFF, 0x00]))
+    #expect(throws: WireFormatError.self) {
+      _ = try FieldValue.decode(from: &decoder)
     }
+  }
 }
 
 @Suite("Table with RabbitMQ Headers Tests")
 struct RabbitMQHeadersTests {
-    @Test("x-message-ttl header")
-    func messageTTL() throws {
-        let table: Table = ["x-message-ttl": .int32(60000)]
-        var encoder = WireEncoder()
-        try encodeTable(table, to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try decodeTable(from: &decoder)
-        #expect(decoded["x-message-ttl"]?.intValue == 60000)
-    }
+  @Test("x-message-ttl header")
+  func messageTTL() throws {
+    let table: Table = ["x-message-ttl": .int32(60000)]
+    var encoder = WireEncoder()
+    try encodeTable(table, to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try decodeTable(from: &decoder)
+    #expect(decoded["x-message-ttl"]?.intValue == 60000)
+  }
 
-    @Test("x-max-length header")
-    func maxLength() throws {
-        let table: Table = ["x-max-length": .int32(1000)]
-        var encoder = WireEncoder()
-        try encodeTable(table, to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try decodeTable(from: &decoder)
-        #expect(decoded["x-max-length"]?.intValue == 1000)
-    }
+  @Test("x-max-length header")
+  func maxLength() throws {
+    let table: Table = ["x-max-length": .int32(1000)]
+    var encoder = WireEncoder()
+    try encodeTable(table, to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try decodeTable(from: &decoder)
+    #expect(decoded["x-max-length"]?.intValue == 1000)
+  }
 
-    @Test("x-dead-letter-exchange header")
-    func deadLetterExchange() throws {
-        let table: Table = ["x-dead-letter-exchange": .string("dlx")]
-        var encoder = WireEncoder()
-        try encodeTable(table, to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try decodeTable(from: &decoder)
-        #expect(decoded["x-dead-letter-exchange"]?.stringValue == "dlx")
-    }
+  @Test("x-dead-letter-exchange header")
+  func deadLetterExchange() throws {
+    let table: Table = ["x-dead-letter-exchange": .string("dlx")]
+    var encoder = WireEncoder()
+    try encodeTable(table, to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try decodeTable(from: &decoder)
+    #expect(decoded["x-dead-letter-exchange"]?.stringValue == "dlx")
+  }
 
-    @Test("x-queue-type header")
-    func queueType() throws {
-        let table: Table = ["x-queue-type": .string("quorum")]
-        var encoder = WireEncoder()
-        try encodeTable(table, to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try decodeTable(from: &decoder)
-        #expect(decoded["x-queue-type"]?.stringValue == "quorum")
-    }
+  @Test("x-queue-type header")
+  func queueType() throws {
+    let table: Table = ["x-queue-type": .string("quorum")]
+    var encoder = WireEncoder()
+    try encodeTable(table, to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try decodeTable(from: &decoder)
+    #expect(decoded["x-queue-type"]?.stringValue == "quorum")
+  }
 
-    @Test("CC and BCC headers (array of strings)")
-    func ccBccHeaders() throws {
-        let table: Table = [
-            "CC": .array([.string("route1"), .string("route2")]),
-            "BCC": .array([.string("hidden1")])
-        ]
-        var encoder = WireEncoder()
-        try encodeTable(table, to: &encoder)
-        var decoder = encoder.encodedData.wireDecoder()
-        let decoded = try decodeTable(from: &decoder)
+  @Test("CC and BCC headers (array of strings)")
+  func ccBccHeaders() throws {
+    let table: Table = [
+      "CC": .array([.string("route1"), .string("route2")]),
+      "BCC": .array([.string("hidden1")]),
+    ]
+    var encoder = WireEncoder()
+    try encodeTable(table, to: &encoder)
+    var decoder = encoder.encodedData.wireDecoder()
+    let decoded = try decodeTable(from: &decoder)
 
-        if case .array(let cc) = decoded["CC"] {
-            #expect(cc.count == 2)
-            #expect(cc[0].stringValue == "route1")
-        } else {
-            Issue.record("Expected CC array")
-        }
+    if case .array(let cc) = decoded["CC"] {
+      #expect(cc.count == 2)
+      #expect(cc[0].stringValue == "route1")
+    } else {
+      Issue.record("Expected CC array")
     }
+  }
 }

--- a/Tests/AMQPProtocolTests/WireFormatTests.swift
+++ b/Tests/AMQPProtocolTests/WireFormatTests.swift
@@ -10,528 +10,532 @@
 
 import Foundation
 import Testing
+
 @testable import AMQPProtocol
 
 @Suite("WireEncoder Tests")
 struct WireEncoderTests {
-    @Test("writeUInt8 encodes single byte")
-    func writeUInt8() {
-        var encoder = WireEncoder()
-        encoder.writeUInt8(0xAB)
-        #expect(encoder.encodedData == Data([0xAB]))
-    }
+  @Test("writeUInt8 encodes single byte")
+  func writeUInt8() {
+    var encoder = WireEncoder()
+    encoder.writeUInt8(0xAB)
+    #expect(encoder.encodedData == Data([0xAB]))
+  }
 
-    @Test("writeInt8 encodes signed byte")
-    func writeInt8() {
-        var encoder = WireEncoder()
-        encoder.writeInt8(-1)
-        #expect(encoder.encodedData == Data([0xFF]))
+  @Test("writeInt8 encodes signed byte")
+  func writeInt8() {
+    var encoder = WireEncoder()
+    encoder.writeInt8(-1)
+    #expect(encoder.encodedData == Data([0xFF]))
 
-        var encoder2 = WireEncoder()
-        encoder2.writeInt8(127)
-        #expect(encoder2.encodedData == Data([0x7F]))
-    }
+    var encoder2 = WireEncoder()
+    encoder2.writeInt8(127)
+    #expect(encoder2.encodedData == Data([0x7F]))
+  }
 
-    @Test("writeUInt16 encodes big-endian 16-bit integer")
-    func writeUInt16() {
-        var encoder = WireEncoder()
-        encoder.writeUInt16(0x1234)
-        #expect(encoder.encodedData == Data([0x12, 0x34]))
-    }
+  @Test("writeUInt16 encodes big-endian 16-bit integer")
+  func writeUInt16() {
+    var encoder = WireEncoder()
+    encoder.writeUInt16(0x1234)
+    #expect(encoder.encodedData == Data([0x12, 0x34]))
+  }
 
-    @Test("writeInt16 encodes signed 16-bit integer")
-    func writeInt16() {
-        var encoder = WireEncoder()
-        encoder.writeInt16(-1)
-        #expect(encoder.encodedData == Data([0xFF, 0xFF]))
-    }
+  @Test("writeInt16 encodes signed 16-bit integer")
+  func writeInt16() {
+    var encoder = WireEncoder()
+    encoder.writeInt16(-1)
+    #expect(encoder.encodedData == Data([0xFF, 0xFF]))
+  }
 
-    @Test("writeUInt32 encodes big-endian 32-bit integer")
-    func writeUInt32() {
-        var encoder = WireEncoder()
-        encoder.writeUInt32(0x12345678)
-        #expect(encoder.encodedData == Data([0x12, 0x34, 0x56, 0x78]))
-    }
+  @Test("writeUInt32 encodes big-endian 32-bit integer")
+  func writeUInt32() {
+    var encoder = WireEncoder()
+    encoder.writeUInt32(0x1234_5678)
+    #expect(encoder.encodedData == Data([0x12, 0x34, 0x56, 0x78]))
+  }
 
-    @Test("writeInt32 encodes signed 32-bit integer")
-    func writeInt32() {
-        var encoder = WireEncoder()
-        encoder.writeInt32(-1)
-        #expect(encoder.encodedData == Data([0xFF, 0xFF, 0xFF, 0xFF]))
-    }
+  @Test("writeInt32 encodes signed 32-bit integer")
+  func writeInt32() {
+    var encoder = WireEncoder()
+    encoder.writeInt32(-1)
+    #expect(encoder.encodedData == Data([0xFF, 0xFF, 0xFF, 0xFF]))
+  }
 
-    @Test("writeUInt64 encodes big-endian 64-bit integer")
-    func writeUInt64() {
-        var encoder = WireEncoder()
-        encoder.writeUInt64(0x123456789ABCDEF0)
-        #expect(encoder.encodedData == Data([0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]))
-    }
+  @Test("writeUInt64 encodes big-endian 64-bit integer")
+  func writeUInt64() {
+    var encoder = WireEncoder()
+    encoder.writeUInt64(0x1234_5678_9ABC_DEF0)
+    #expect(encoder.encodedData == Data([0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]))
+  }
 
-    @Test("writeInt64 encodes signed 64-bit integer")
-    func writeInt64() {
-        var encoder = WireEncoder()
-        encoder.writeInt64(-1)
-        #expect(encoder.encodedData == Data([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]))
-    }
+  @Test("writeInt64 encodes signed 64-bit integer")
+  func writeInt64() {
+    var encoder = WireEncoder()
+    encoder.writeInt64(-1)
+    #expect(encoder.encodedData == Data([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]))
+  }
 
-    @Test("writeFloat encodes IEEE 754 float")
-    func writeFloat() {
-        var encoder = WireEncoder()
-        encoder.writeFloat(1.0)
-        // 1.0 in IEEE 754 = 0x3F800000
-        #expect(encoder.encodedData == Data([0x3F, 0x80, 0x00, 0x00]))
-    }
+  @Test("writeFloat encodes IEEE 754 float")
+  func writeFloat() {
+    var encoder = WireEncoder()
+    encoder.writeFloat(1.0)
+    // 1.0 in IEEE 754 = 0x3F800000
+    #expect(encoder.encodedData == Data([0x3F, 0x80, 0x00, 0x00]))
+  }
 
-    @Test("writeDouble encodes IEEE 754 double")
-    func writeDouble() {
-        var encoder = WireEncoder()
-        encoder.writeDouble(1.0)
-        // 1.0 in IEEE 754 double = 0x3FF0000000000000
-        #expect(encoder.encodedData == Data([0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
-    }
+  @Test("writeDouble encodes IEEE 754 double")
+  func writeDouble() {
+    var encoder = WireEncoder()
+    encoder.writeDouble(1.0)
+    // 1.0 in IEEE 754 double = 0x3FF0000000000000
+    #expect(encoder.encodedData == Data([0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+  }
 
-    @Test("writeShortString encodes length-prefixed string")
-    func writeShortString() throws {
-        var encoder = WireEncoder()
-        try encoder.writeShortString("hello")
-        #expect(encoder.encodedData == Data([5, 0x68, 0x65, 0x6C, 0x6C, 0x6F]))
-    }
+  @Test("writeShortString encodes length-prefixed string")
+  func writeShortString() throws {
+    var encoder = WireEncoder()
+    try encoder.writeShortString("hello")
+    #expect(encoder.encodedData == Data([5, 0x68, 0x65, 0x6C, 0x6C, 0x6F]))
+  }
 
-    @Test("writeShortString throws for strings over 255 bytes")
-    func writeShortStringTooLong() {
-        var encoder = WireEncoder()
-        let longString = String(repeating: "x", count: 256)
-        #expect(throws: WireFormatError.self) {
-            try encoder.writeShortString(longString)
-        }
+  @Test("writeShortString throws for strings over 255 bytes")
+  func writeShortStringTooLong() {
+    var encoder = WireEncoder()
+    let longString = String(repeating: "x", count: 256)
+    #expect(throws: WireFormatError.self) {
+      try encoder.writeShortString(longString)
     }
+  }
 
-    @Test("writeLongString encodes 32-bit length prefix")
-    func writeLongString() {
-        var encoder = WireEncoder()
-        encoder.writeLongString("test")
-        #expect(encoder.encodedData == Data([0x00, 0x00, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74]))
-    }
+  @Test("writeLongString encodes 32-bit length prefix")
+  func writeLongString() {
+    var encoder = WireEncoder()
+    encoder.writeLongString("test")
+    #expect(encoder.encodedData == Data([0x00, 0x00, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74]))
+  }
 
-    @Test("writeBits packs booleans into bytes")
-    func writeBits() {
-        var encoder = WireEncoder()
-        encoder.writeBits([true, false, true, false, false, false, false, true])
-        // bits: 1,0,1,0,0,0,0,1 = 0b10000101 = 0x85
-        #expect(encoder.encodedData == Data([0x85]))
-    }
+  @Test("writeBits packs booleans into bytes")
+  func writeBits() {
+    var encoder = WireEncoder()
+    encoder.writeBits([true, false, true, false, false, false, false, true])
+    // bits: 1,0,1,0,0,0,0,1 = 0b10000101 = 0x85
+    #expect(encoder.encodedData == Data([0x85]))
+  }
 
-    @Test("writeBits handles fewer than 8 bits")
-    func writeBitsPartial() {
-        var encoder = WireEncoder()
-        encoder.writeBits([true, true, false])
-        // bits: 1,1,0 padded with zeros = 0b00000011 = 0x03
-        #expect(encoder.encodedData == Data([0x03]))
-    }
+  @Test("writeBits handles fewer than 8 bits")
+  func writeBitsPartial() {
+    var encoder = WireEncoder()
+    encoder.writeBits([true, true, false])
+    // bits: 1,1,0 padded with zeros = 0b00000011 = 0x03
+    #expect(encoder.encodedData == Data([0x03]))
+  }
 
-    @Test("writeBits handles more than 8 bits")
-    func writeBitsMultipleBytes() {
-        var encoder = WireEncoder()
-        encoder.writeBits([true, false, true, false, true, false, true, false, true])
-        // First byte: 0b01010101 = 0x55, Second byte: 0b00000001 = 0x01
-        #expect(encoder.encodedData == Data([0x55, 0x01]))
-    }
+  @Test("writeBits handles more than 8 bits")
+  func writeBitsMultipleBytes() {
+    var encoder = WireEncoder()
+    encoder.writeBits([true, false, true, false, true, false, true, false, true])
+    // First byte: 0b01010101 = 0x55, Second byte: 0b00000001 = 0x01
+    #expect(encoder.encodedData == Data([0x55, 0x01]))
+  }
 
-    @Test("writeBoolean encodes as single byte")
-    func writeBoolean() {
-        var encoder = WireEncoder()
-        encoder.writeBoolean(true)
-        encoder.writeBoolean(false)
-        #expect(encoder.encodedData == Data([0x01, 0x00]))
-    }
+  @Test("writeBoolean encodes as single byte")
+  func writeBoolean() {
+    var encoder = WireEncoder()
+    encoder.writeBoolean(true)
+    encoder.writeBoolean(false)
+    #expect(encoder.encodedData == Data([0x01, 0x00]))
+  }
 }
 
 @Suite("WireDecoder Tests")
 struct WireDecoderTests {
-    @Test("readUInt8 decodes single byte")
-    func readUInt8() throws {
-        var decoder = WireDecoder(Data([0xAB]))
-        let value = try decoder.readUInt8()
-        #expect(value == 0xAB)
-        #expect(decoder.remaining == 0)
-    }
+  @Test("readUInt8 decodes single byte")
+  func readUInt8() throws {
+    var decoder = WireDecoder(Data([0xAB]))
+    let value = try decoder.readUInt8()
+    #expect(value == 0xAB)
+    #expect(decoder.remaining == 0)
+  }
 
-    @Test("readInt8 decodes signed byte")
-    func readInt8() throws {
-        var decoder = WireDecoder(Data([0xFF]))
-        let value = try decoder.readInt8()
-        #expect(value == -1)
-    }
+  @Test("readInt8 decodes signed byte")
+  func readInt8() throws {
+    var decoder = WireDecoder(Data([0xFF]))
+    let value = try decoder.readInt8()
+    #expect(value == -1)
+  }
 
-    @Test("readUInt16 decodes big-endian 16-bit integer")
-    func readUInt16() throws {
-        var decoder = WireDecoder(Data([0x12, 0x34]))
-        let value = try decoder.readUInt16()
-        #expect(value == 0x1234)
-    }
+  @Test("readUInt16 decodes big-endian 16-bit integer")
+  func readUInt16() throws {
+    var decoder = WireDecoder(Data([0x12, 0x34]))
+    let value = try decoder.readUInt16()
+    #expect(value == 0x1234)
+  }
 
-    @Test("readInt16 decodes signed 16-bit integer")
-    func readInt16() throws {
-        var decoder = WireDecoder(Data([0xFF, 0xFF]))
-        let value = try decoder.readInt16()
-        #expect(value == -1)
-    }
+  @Test("readInt16 decodes signed 16-bit integer")
+  func readInt16() throws {
+    var decoder = WireDecoder(Data([0xFF, 0xFF]))
+    let value = try decoder.readInt16()
+    #expect(value == -1)
+  }
 
-    @Test("readUInt32 decodes big-endian 32-bit integer")
-    func readUInt32() throws {
-        var decoder = WireDecoder(Data([0x12, 0x34, 0x56, 0x78]))
-        let value = try decoder.readUInt32()
-        #expect(value == 0x12345678)
-    }
+  @Test("readUInt32 decodes big-endian 32-bit integer")
+  func readUInt32() throws {
+    var decoder = WireDecoder(Data([0x12, 0x34, 0x56, 0x78]))
+    let value = try decoder.readUInt32()
+    #expect(value == 0x1234_5678)
+  }
 
-    @Test("readInt32 decodes signed 32-bit integer")
-    func readInt32() throws {
-        var decoder = WireDecoder(Data([0xFF, 0xFF, 0xFF, 0xFF]))
-        let value = try decoder.readInt32()
-        #expect(value == -1)
-    }
+  @Test("readInt32 decodes signed 32-bit integer")
+  func readInt32() throws {
+    var decoder = WireDecoder(Data([0xFF, 0xFF, 0xFF, 0xFF]))
+    let value = try decoder.readInt32()
+    #expect(value == -1)
+  }
 
-    @Test("readUInt64 decodes big-endian 64-bit integer")
-    func readUInt64() throws {
-        var decoder = WireDecoder(Data([0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]))
-        let value = try decoder.readUInt64()
-        #expect(value == 0x123456789ABCDEF0)
-    }
+  @Test("readUInt64 decodes big-endian 64-bit integer")
+  func readUInt64() throws {
+    var decoder = WireDecoder(Data([0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]))
+    let value = try decoder.readUInt64()
+    #expect(value == 0x1234_5678_9ABC_DEF0)
+  }
 
-    @Test("readInt64 decodes signed 64-bit integer")
-    func readInt64() throws {
-        var decoder = WireDecoder(Data([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]))
-        let value = try decoder.readInt64()
-        #expect(value == -1)
-    }
+  @Test("readInt64 decodes signed 64-bit integer")
+  func readInt64() throws {
+    var decoder = WireDecoder(Data([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]))
+    let value = try decoder.readInt64()
+    #expect(value == -1)
+  }
 
-    @Test("readFloat decodes IEEE 754 float")
-    func readFloat() throws {
-        var decoder = WireDecoder(Data([0x3F, 0x80, 0x00, 0x00]))
-        let value = try decoder.readFloat()
-        #expect(value == 1.0)
-    }
+  @Test("readFloat decodes IEEE 754 float")
+  func readFloat() throws {
+    var decoder = WireDecoder(Data([0x3F, 0x80, 0x00, 0x00]))
+    let value = try decoder.readFloat()
+    #expect(value == 1.0)
+  }
 
-    @Test("readDouble decodes IEEE 754 double")
-    func readDouble() throws {
-        var decoder = WireDecoder(Data([0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
-        let value = try decoder.readDouble()
-        #expect(value == 1.0)
-    }
+  @Test("readDouble decodes IEEE 754 double")
+  func readDouble() throws {
+    var decoder = WireDecoder(Data([0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+    let value = try decoder.readDouble()
+    #expect(value == 1.0)
+  }
 
-    @Test("readShortString decodes length-prefixed string")
-    func readShortString() throws {
-        var decoder = WireDecoder(Data([5, 0x68, 0x65, 0x6C, 0x6C, 0x6F]))
-        let value = try decoder.readShortString()
-        #expect(value == "hello")
-    }
+  @Test("readShortString decodes length-prefixed string")
+  func readShortString() throws {
+    var decoder = WireDecoder(Data([5, 0x68, 0x65, 0x6C, 0x6C, 0x6F]))
+    let value = try decoder.readShortString()
+    #expect(value == "hello")
+  }
 
-    @Test("readLongString decodes 32-bit length-prefixed string")
-    func readLongString() throws {
-        var decoder = WireDecoder(Data([0x00, 0x00, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74]))
-        let value = try decoder.readLongString()
-        #expect(value == "test")
-    }
+  @Test("readLongString decodes 32-bit length-prefixed string")
+  func readLongString() throws {
+    var decoder = WireDecoder(Data([0x00, 0x00, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74]))
+    let value = try decoder.readLongString()
+    #expect(value == "test")
+  }
 
-    @Test("readBits unpacks booleans from bytes")
-    func readBits() throws {
-        var decoder = WireDecoder(Data([0x85]))
-        let bits = try decoder.readBits(8)
-        #expect(bits == [true, false, true, false, false, false, false, true])
-    }
+  @Test("readBits unpacks booleans from bytes")
+  func readBits() throws {
+    var decoder = WireDecoder(Data([0x85]))
+    let bits = try decoder.readBits(8)
+    #expect(bits == [true, false, true, false, false, false, false, true])
+  }
 
-    @Test("readBits handles fewer than 8 bits")
-    func readBitsPartial() throws {
-        var decoder = WireDecoder(Data([0x03]))
-        let bits = try decoder.readBits(3)
-        #expect(bits == [true, true, false])
-    }
+  @Test("readBits handles fewer than 8 bits")
+  func readBitsPartial() throws {
+    var decoder = WireDecoder(Data([0x03]))
+    let bits = try decoder.readBits(3)
+    #expect(bits == [true, true, false])
+  }
 
-    @Test("readBoolean decodes single byte to bool")
-    func readBoolean() throws {
-        var decoder = WireDecoder(Data([0x01, 0x00]))
-        #expect(try decoder.readBoolean() == true)
-        #expect(try decoder.readBoolean() == false)
-    }
+  @Test("readBoolean decodes single byte to bool")
+  func readBoolean() throws {
+    var decoder = WireDecoder(Data([0x01, 0x00]))
+    #expect(try decoder.readBoolean() == true)
+    #expect(try decoder.readBoolean() == false)
+  }
 
-    @Test("peekUInt8 reads without advancing position")
-    func peekUInt8() throws {
-        let decoder = WireDecoder(Data([0xAB, 0xCD]))
-        let value = try decoder.peekUInt8()
-        #expect(value == 0xAB)
-        #expect(decoder.position == 0)
-    }
+  @Test("peekUInt8 reads without advancing position")
+  func peekUInt8() throws {
+    let decoder = WireDecoder(Data([0xAB, 0xCD]))
+    let value = try decoder.peekUInt8()
+    #expect(value == 0xAB)
+    #expect(decoder.position == 0)
+  }
 
-    @Test("skip advances position")
-    func skip() throws {
-        var decoder = WireDecoder(Data([0x01, 0x02, 0x03, 0x04]))
-        try decoder.skip(2)
-        let value = try decoder.readUInt8()
-        #expect(value == 0x03)
-    }
+  @Test("skip advances position")
+  func skip() throws {
+    var decoder = WireDecoder(Data([0x01, 0x02, 0x03, 0x04]))
+    try decoder.skip(2)
+    let value = try decoder.readUInt8()
+    #expect(value == 0x03)
+  }
 
-    @Test("throws on insufficient data")
-    func insufficientData() {
-        var decoder = WireDecoder(Data([0x01]))
-        #expect(throws: WireFormatError.self) {
-            _ = try decoder.readUInt16()
-        }
+  @Test("throws on insufficient data")
+  func insufficientData() {
+    var decoder = WireDecoder(Data([0x01]))
+    #expect(throws: WireFormatError.self) {
+      _ = try decoder.readUInt16()
     }
+  }
 }
 
 @Suite("Wire Format Roundtrip Tests")
 struct WireFormatRoundtripTests {
-    @Test("UInt8 roundtrip", arguments: [UInt8.min, UInt8.max, 0, 1, 127, 128, 255])
-    func uint8Roundtrip(value: UInt8) throws {
-        var encoder = WireEncoder()
-        encoder.writeUInt8(value)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readUInt8() == value)
-    }
+  @Test("UInt8 roundtrip", arguments: [UInt8.min, UInt8.max, 0, 1, 127, 128, 255])
+  func uint8Roundtrip(value: UInt8) throws {
+    var encoder = WireEncoder()
+    encoder.writeUInt8(value)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readUInt8() == value)
+  }
 
-    @Test("Int8 roundtrip", arguments: [Int8.min, Int8.max, 0, 1, -1, 127, -128])
-    func int8Roundtrip(value: Int8) throws {
-        var encoder = WireEncoder()
-        encoder.writeInt8(value)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readInt8() == value)
-    }
+  @Test("Int8 roundtrip", arguments: [Int8.min, Int8.max, 0, 1, -1, 127, -128])
+  func int8Roundtrip(value: Int8) throws {
+    var encoder = WireEncoder()
+    encoder.writeInt8(value)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readInt8() == value)
+  }
 
-    @Test("UInt16 roundtrip", arguments: [UInt16.min, UInt16.max, 0, 1, 0x1234, 0xFF00, 0x00FF])
-    func uint16Roundtrip(value: UInt16) throws {
-        var encoder = WireEncoder()
-        encoder.writeUInt16(value)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readUInt16() == value)
-    }
+  @Test("UInt16 roundtrip", arguments: [UInt16.min, UInt16.max, 0, 1, 0x1234, 0xFF00, 0x00FF])
+  func uint16Roundtrip(value: UInt16) throws {
+    var encoder = WireEncoder()
+    encoder.writeUInt16(value)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readUInt16() == value)
+  }
 
-    @Test("Int16 roundtrip", arguments: [Int16.min, Int16.max, 0, 1, -1, 0x1234, -0x1234])
-    func int16Roundtrip(value: Int16) throws {
-        var encoder = WireEncoder()
-        encoder.writeInt16(value)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readInt16() == value)
-    }
+  @Test("Int16 roundtrip", arguments: [Int16.min, Int16.max, 0, 1, -1, 0x1234, -0x1234])
+  func int16Roundtrip(value: Int16) throws {
+    var encoder = WireEncoder()
+    encoder.writeInt16(value)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readInt16() == value)
+  }
 
-    @Test("UInt32 roundtrip", arguments: [UInt32.min, UInt32.max, 0, 1, 0x12345678, 0xFF000000])
-    func uint32Roundtrip(value: UInt32) throws {
-        var encoder = WireEncoder()
-        encoder.writeUInt32(value)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readUInt32() == value)
-    }
+  @Test("UInt32 roundtrip", arguments: [UInt32.min, UInt32.max, 0, 1, 0x1234_5678, 0xFF00_0000])
+  func uint32Roundtrip(value: UInt32) throws {
+    var encoder = WireEncoder()
+    encoder.writeUInt32(value)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readUInt32() == value)
+  }
 
-    @Test("Int32 roundtrip", arguments: [Int32.min, Int32.max, 0, 1, -1, 0x12345678, -0x12345678])
-    func int32Roundtrip(value: Int32) throws {
-        var encoder = WireEncoder()
-        encoder.writeInt32(value)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readInt32() == value)
-    }
+  @Test("Int32 roundtrip", arguments: [Int32.min, Int32.max, 0, 1, -1, 0x1234_5678, -0x1234_5678])
+  func int32Roundtrip(value: Int32) throws {
+    var encoder = WireEncoder()
+    encoder.writeInt32(value)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readInt32() == value)
+  }
 
-    @Test("UInt64 roundtrip")
-    func uint64Roundtrip() throws {
-        let values: [UInt64] = [UInt64.min, UInt64.max, 0, 1, 0x123456789ABCDEF0]
-        for value in values {
-            var encoder = WireEncoder()
-            encoder.writeUInt64(value)
-            var decoder = encoder.encodedData.wireDecoder()
-            #expect(try decoder.readUInt64() == value)
-        }
+  @Test("UInt64 roundtrip")
+  func uint64Roundtrip() throws {
+    let values: [UInt64] = [UInt64.min, UInt64.max, 0, 1, 0x1234_5678_9ABC_DEF0]
+    for value in values {
+      var encoder = WireEncoder()
+      encoder.writeUInt64(value)
+      var decoder = encoder.encodedData.wireDecoder()
+      #expect(try decoder.readUInt64() == value)
     }
+  }
 
-    @Test("Int64 roundtrip")
-    func int64Roundtrip() throws {
-        let values: [Int64] = [Int64.min, Int64.max, 0, 1, -1, 0x123456789ABCDEF0]
-        for value in values {
-            var encoder = WireEncoder()
-            encoder.writeInt64(value)
-            var decoder = encoder.encodedData.wireDecoder()
-            #expect(try decoder.readInt64() == value)
-        }
+  @Test("Int64 roundtrip")
+  func int64Roundtrip() throws {
+    let values: [Int64] = [Int64.min, Int64.max, 0, 1, -1, 0x1234_5678_9ABC_DEF0]
+    for value in values {
+      var encoder = WireEncoder()
+      encoder.writeInt64(value)
+      var decoder = encoder.encodedData.wireDecoder()
+      #expect(try decoder.readInt64() == value)
     }
+  }
 
-    @Test("Float roundtrip", arguments: [Float.zero, 1.0, -1.0, Float.pi, Float.greatestFiniteMagnitude])
-    func floatRoundtrip(value: Float) throws {
-        var encoder = WireEncoder()
-        encoder.writeFloat(value)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readFloat() == value)
-    }
+  @Test(
+    "Float roundtrip", arguments: [Float.zero, 1.0, -1.0, Float.pi, Float.greatestFiniteMagnitude])
+  func floatRoundtrip(value: Float) throws {
+    var encoder = WireEncoder()
+    encoder.writeFloat(value)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readFloat() == value)
+  }
 
-    @Test("Double roundtrip", arguments: [Double.zero, 1.0, -1.0, Double.pi, Double.greatestFiniteMagnitude])
-    func doubleRoundtrip(value: Double) throws {
-        var encoder = WireEncoder()
-        encoder.writeDouble(value)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readDouble() == value)
-    }
+  @Test(
+    "Double roundtrip",
+    arguments: [Double.zero, 1.0, -1.0, Double.pi, Double.greatestFiniteMagnitude])
+  func doubleRoundtrip(value: Double) throws {
+    var encoder = WireEncoder()
+    encoder.writeDouble(value)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readDouble() == value)
+  }
 
-    @Test("Short string roundtrip", arguments: ["", "hello", "test123", "unicode: 日本語"])
-    func shortStringRoundtrip(value: String) throws {
-        var encoder = WireEncoder()
-        try encoder.writeShortString(value)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readShortString() == value)
-    }
+  @Test("Short string roundtrip", arguments: ["", "hello", "test123", "unicode: 日本語"])
+  func shortStringRoundtrip(value: String) throws {
+    var encoder = WireEncoder()
+    try encoder.writeShortString(value)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readShortString() == value)
+  }
 
-    @Test("Long string roundtrip")
-    func longStringRoundtrip() throws {
-        let values = ["", "hello", String(repeating: "x", count: 1000)]
-        for value in values {
-            var encoder = WireEncoder()
-            encoder.writeLongString(value)
-            var decoder = encoder.encodedData.wireDecoder()
-            #expect(try decoder.readLongString() == value)
-        }
+  @Test("Long string roundtrip")
+  func longStringRoundtrip() throws {
+    let values = ["", "hello", String(repeating: "x", count: 1000)]
+    for value in values {
+      var encoder = WireEncoder()
+      encoder.writeLongString(value)
+      var decoder = encoder.encodedData.wireDecoder()
+      #expect(try decoder.readLongString() == value)
     }
+  }
 
-    @Test("Bytes roundtrip")
-    func bytesRoundtrip() throws {
-        let values = [Data(), Data([0x01, 0x02, 0x03]), Data(repeating: 0xAB, count: 100)]
-        for value in values {
-            var encoder = WireEncoder()
-            encoder.writeLongBytes(value)
-            var decoder = encoder.encodedData.wireDecoder()
-            #expect(try decoder.readLongBytes() == value)
-        }
+  @Test("Bytes roundtrip")
+  func bytesRoundtrip() throws {
+    let values = [Data(), Data([0x01, 0x02, 0x03]), Data(repeating: 0xAB, count: 100)]
+    for value in values {
+      var encoder = WireEncoder()
+      encoder.writeLongBytes(value)
+      var decoder = encoder.encodedData.wireDecoder()
+      #expect(try decoder.readLongBytes() == value)
     }
+  }
 
-    @Test("Boolean roundtrip", arguments: [true, false])
-    func booleanRoundtrip(value: Bool) throws {
-        var encoder = WireEncoder()
-        encoder.writeBoolean(value)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readBoolean() == value)
-    }
+  @Test("Boolean roundtrip", arguments: [true, false])
+  func booleanRoundtrip(value: Bool) throws {
+    var encoder = WireEncoder()
+    encoder.writeBoolean(value)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readBoolean() == value)
+  }
 
-    @Test("Bits roundtrip")
-    func bitsRoundtrip() throws {
-        let testCases: [[Bool]] = [
-            [true],
-            [false],
-            [true, false],
-            [true, true, true],
-            [false, false, false, false],
-            [true, false, true, false, true, false, true, false],
-            [true, false, true, false, true, false, true, false, true],
-        ]
-        for bits in testCases {
-            var encoder = WireEncoder()
-            encoder.writeBits(bits)
-            var decoder = encoder.encodedData.wireDecoder()
-            let decoded = try decoder.readBits(bits.count)
-            #expect(decoded == bits, "Failed for bits: \(bits)")
-        }
+  @Test("Bits roundtrip")
+  func bitsRoundtrip() throws {
+    let testCases: [[Bool]] = [
+      [true],
+      [false],
+      [true, false],
+      [true, true, true],
+      [false, false, false, false],
+      [true, false, true, false, true, false, true, false],
+      [true, false, true, false, true, false, true, false, true],
+    ]
+    for bits in testCases {
+      var encoder = WireEncoder()
+      encoder.writeBits(bits)
+      var decoder = encoder.encodedData.wireDecoder()
+      let decoded = try decoder.readBits(bits.count)
+      #expect(decoded == bits, "Failed for bits: \(bits)")
     }
+  }
 }
 
 @Suite("Wire Format Edge Cases")
 struct WireFormatEdgeCaseTests {
-    @Test("Empty data handling")
-    func emptyData() {
-        let decoder = WireDecoder(Data())
-        #expect(decoder.remaining == 0)
-        #expect(decoder.hasMore == false)
+  @Test("Empty data handling")
+  func emptyData() {
+    let decoder = WireDecoder(Data())
+    #expect(decoder.remaining == 0)
+    #expect(decoder.hasMore == false)
+  }
+
+  @Test("UTF-8 string encoding")
+  func utf8Strings() throws {
+    let strings = ["ASCII", "Ümläut", "日本語", "🎉🚀", "Mixed: café ☕"]
+    for str in strings {
+      var encoder = WireEncoder()
+      try encoder.writeShortString(str)
+      var decoder = encoder.encodedData.wireDecoder()
+      #expect(try decoder.readShortString() == str)
     }
+  }
 
-    @Test("UTF-8 string encoding")
-    func utf8Strings() throws {
-        let strings = ["ASCII", "Ümläut", "日本語", "🎉🚀", "Mixed: café ☕"]
-        for str in strings {
-            var encoder = WireEncoder()
-            try encoder.writeShortString(str)
-            var decoder = encoder.encodedData.wireDecoder()
-            #expect(try decoder.readShortString() == str)
-        }
+  @Test("Maximum short string length")
+  func maxShortString() throws {
+    let maxString = String(repeating: "x", count: 255)
+    var encoder = WireEncoder()
+    try encoder.writeShortString(maxString)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readShortString() == maxString)
+  }
+
+  @Test("Sequential reads consume buffer correctly")
+  func sequentialReads() throws {
+    var encoder = WireEncoder()
+    encoder.writeUInt8(1)
+    encoder.writeUInt16(2)
+    encoder.writeUInt32(3)
+    encoder.writeUInt64(4)
+
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readUInt8() == 1)
+    #expect(try decoder.readUInt16() == 2)
+    #expect(try decoder.readUInt32() == 3)
+    #expect(try decoder.readUInt64() == 4)
+    #expect(decoder.remaining == 0)
+  }
+
+  @Test("Short string with multibyte UTF-8 at limit")
+  func shortStringMultibyteLimit() throws {
+    // 63 emoji * 4 bytes each = 252 bytes, plus 3 ASCII = 255 bytes exactly
+    let emoji = String(repeating: "🎉", count: 63)
+    let str = emoji + "abc"
+    #expect(str.utf8.count == 255)
+
+    var encoder = WireEncoder()
+    try encoder.writeShortString(str)
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readShortString() == str)
+  }
+
+  @Test("Short string exceeds limit with multibyte")
+  func shortStringMultibyteExceedsLimit() {
+    // 64 emoji * 4 bytes = 256 bytes, exceeds limit
+    let str = String(repeating: "🎉", count: 64)
+    #expect(str.utf8.count == 256)
+
+    var encoder = WireEncoder()
+    #expect(throws: WireFormatError.self) {
+      try encoder.writeShortString(str)
     }
+  }
 
-    @Test("Maximum short string length")
-    func maxShortString() throws {
-        let maxString = String(repeating: "x", count: 255)
-        var encoder = WireEncoder()
-        try encoder.writeShortString(maxString)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readShortString() == maxString)
-    }
+  @Test("Peek operations do not consume data")
+  func peekDoesNotConsume() throws {
+    let decoder = WireDecoder(Data([0x12, 0x34, 0x56, 0x78]))
+    let peeked = try decoder.peekBytes(4)
+    #expect(peeked == Data([0x12, 0x34, 0x56, 0x78]))
+    #expect(decoder.position == 0)
+    #expect(decoder.remaining == 4)
+  }
 
-    @Test("Sequential reads consume buffer correctly")
-    func sequentialReads() throws {
-        var encoder = WireEncoder()
-        encoder.writeUInt8(1)
-        encoder.writeUInt16(2)
-        encoder.writeUInt32(3)
-        encoder.writeUInt64(4)
+  @Test("Read raw bytes")
+  func readRawBytes() throws {
+    var decoder = WireDecoder(Data([0x01, 0x02, 0x03, 0x04, 0x05]))
+    let bytes = try decoder.readBytes(3)
+    #expect(bytes == Data([0x01, 0x02, 0x03]))
+    #expect(decoder.remaining == 2)
+  }
 
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readUInt8() == 1)
-        #expect(try decoder.readUInt16() == 2)
-        #expect(try decoder.readUInt32() == 3)
-        #expect(try decoder.readUInt64() == 4)
-        #expect(decoder.remaining == 0)
-    }
+  @Test("Write raw bytes")
+  func writeRawBytes() {
+    var encoder = WireEncoder()
+    encoder.writeBytes(Data([0xDE, 0xAD, 0xBE, 0xEF]))
+    #expect(encoder.encodedData == Data([0xDE, 0xAD, 0xBE, 0xEF]))
+  }
 
-    @Test("Short string with multibyte UTF-8 at limit")
-    func shortStringMultibyteLimit() throws {
-        // 63 emoji * 4 bytes each = 252 bytes, plus 3 ASCII = 255 bytes exactly
-        let emoji = String(repeating: "🎉", count: 63)
-        let str = emoji + "abc"
-        #expect(str.utf8.count == 255)
+  @Test("Boundary values for integers")
+  func boundaryValues() throws {
+    var encoder = WireEncoder()
+    encoder.writeUInt16(UInt16.max)
+    encoder.writeUInt32(UInt32.max)
+    encoder.writeInt16(Int16.min)
+    encoder.writeInt32(Int32.min)
 
-        var encoder = WireEncoder()
-        try encoder.writeShortString(str)
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readShortString() == str)
-    }
-
-    @Test("Short string exceeds limit with multibyte")
-    func shortStringMultibyteExceedsLimit() {
-        // 64 emoji * 4 bytes = 256 bytes, exceeds limit
-        let str = String(repeating: "🎉", count: 64)
-        #expect(str.utf8.count == 256)
-
-        var encoder = WireEncoder()
-        #expect(throws: WireFormatError.self) {
-            try encoder.writeShortString(str)
-        }
-    }
-
-    @Test("Peek operations do not consume data")
-    func peekDoesNotConsume() throws {
-        let decoder = WireDecoder(Data([0x12, 0x34, 0x56, 0x78]))
-        let peeked = try decoder.peekBytes(4)
-        #expect(peeked == Data([0x12, 0x34, 0x56, 0x78]))
-        #expect(decoder.position == 0)
-        #expect(decoder.remaining == 4)
-    }
-
-    @Test("Read raw bytes")
-    func readRawBytes() throws {
-        var decoder = WireDecoder(Data([0x01, 0x02, 0x03, 0x04, 0x05]))
-        let bytes = try decoder.readBytes(3)
-        #expect(bytes == Data([0x01, 0x02, 0x03]))
-        #expect(decoder.remaining == 2)
-    }
-
-    @Test("Write raw bytes")
-    func writeRawBytes() {
-        var encoder = WireEncoder()
-        encoder.writeBytes(Data([0xDE, 0xAD, 0xBE, 0xEF]))
-        #expect(encoder.encodedData == Data([0xDE, 0xAD, 0xBE, 0xEF]))
-    }
-
-    @Test("Boundary values for integers")
-    func boundaryValues() throws {
-        var encoder = WireEncoder()
-        encoder.writeUInt16(UInt16.max)
-        encoder.writeUInt32(UInt32.max)
-        encoder.writeInt16(Int16.min)
-        encoder.writeInt32(Int32.min)
-
-        var decoder = encoder.encodedData.wireDecoder()
-        #expect(try decoder.readUInt16() == UInt16.max)
-        #expect(try decoder.readUInt32() == UInt32.max)
-        #expect(try decoder.readInt16() == Int16.min)
-        #expect(try decoder.readInt32() == Int32.min)
-    }
+    var decoder = encoder.encodedData.wireDecoder()
+    #expect(try decoder.readUInt16() == UInt16.max)
+    #expect(try decoder.readUInt32() == UInt32.max)
+    #expect(try decoder.readInt16() == Int16.min)
+    #expect(try decoder.readInt32() == Int32.min)
+  }
 }

--- a/Tests/BunnySwiftTests/BunnySwiftTests.swift
+++ b/Tests/BunnySwiftTests/BunnySwiftTests.swift
@@ -7,71 +7,72 @@
 
 // BunnySwift Tests
 
-import Testing
-@testable import BunnySwift
 import AMQPProtocol
+import Testing
+
+@testable import BunnySwift
 
 @Suite("BunnySwift Tests")
 struct BunnySwiftTests {
-    @Test("Module imports correctly")
-    func moduleImports() {
-        // Placeholder for future tests
-    }
+  @Test("Module imports correctly")
+  func moduleImports() {
+    // Placeholder for future tests
+  }
 }
 
 @Suite("QueueType Tests")
 struct QueueTypeTests {
-    @Test("rawValue returns correct strings")
-    func rawValueReturnsCorrectStrings() {
-        #expect(QueueType.classic.rawValue == "classic")
-        #expect(QueueType.quorum.rawValue == "quorum")
-        #expect(QueueType.stream.rawValue == "stream")
-        #expect(QueueType.custom("x-my-type").rawValue == "x-my-type")
-    }
+  @Test("rawValue returns correct strings")
+  func rawValueReturnsCorrectStrings() {
+    #expect(QueueType.classic.rawValue == "classic")
+    #expect(QueueType.quorum.rawValue == "quorum")
+    #expect(QueueType.stream.rawValue == "stream")
+    #expect(QueueType.custom("x-my-type").rawValue == "x-my-type")
+  }
 
-    @Test("custom type preserves arbitrary values")
-    func customTypePreservesArbitraryValues() {
-        let custom1 = QueueType.custom("x-priority-queue")
-        let custom2 = QueueType.custom("x-delayed-message")
+  @Test("custom type preserves arbitrary values")
+  func customTypePreservesArbitraryValues() {
+    let custom1 = QueueType.custom("x-priority-queue")
+    let custom2 = QueueType.custom("x-delayed-message")
 
-        #expect(custom1.rawValue == "x-priority-queue")
-        #expect(custom2.rawValue == "x-delayed-message")
-    }
+    #expect(custom1.rawValue == "x-priority-queue")
+    #expect(custom2.rawValue == "x-delayed-message")
+  }
 
-    @Test("asTableValue wraps rawValue in FieldValue.string")
-    func asTableValueWrapsRawValue() {
-        #expect(QueueType.classic.asTableValue == .string("classic"))
-        #expect(QueueType.quorum.asTableValue == .string("quorum"))
-        #expect(QueueType.stream.asTableValue == .string("stream"))
-        #expect(QueueType.custom("x-test").asTableValue == .string("x-test"))
-    }
+  @Test("asTableValue wraps rawValue in FieldValue.string")
+  func asTableValueWrapsRawValue() {
+    #expect(QueueType.classic.asTableValue == .string("classic"))
+    #expect(QueueType.quorum.asTableValue == .string("quorum"))
+    #expect(QueueType.stream.asTableValue == .string("stream"))
+    #expect(QueueType.custom("x-test").asTableValue == .string("x-test"))
+  }
 
-    @Test("QueueType is Hashable")
-    func queueTypeIsHashable() {
-        var set = Set<QueueType>()
-        set.insert(.classic)
-        set.insert(.quorum)
-        set.insert(.stream)
-        set.insert(.custom("x-test"))
+  @Test("QueueType is Hashable")
+  func queueTypeIsHashable() {
+    var set = Set<QueueType>()
+    set.insert(.classic)
+    set.insert(.quorum)
+    set.insert(.stream)
+    set.insert(.custom("x-test"))
 
-        #expect(set.count == 4)
-        #expect(set.contains(.classic))
-        #expect(set.contains(.custom("x-test")))
-    }
+    #expect(set.count == 4)
+    #expect(set.contains(.classic))
+    #expect(set.contains(.custom("x-test")))
+  }
 
-    @Test("QueueType equality")
-    func queueTypeEquality() {
-        #expect(QueueType.classic == QueueType.classic)
-        #expect(QueueType.quorum != QueueType.stream)
-        #expect(QueueType.custom("x-a") == QueueType.custom("x-a"))
-        #expect(QueueType.custom("x-a") != QueueType.custom("x-b"))
-    }
+  @Test("QueueType equality")
+  func queueTypeEquality() {
+    #expect(QueueType.classic == QueueType.classic)
+    #expect(QueueType.quorum != QueueType.stream)
+    #expect(QueueType.custom("x-a") == QueueType.custom("x-a"))
+    #expect(QueueType.custom("x-a") != QueueType.custom("x-b"))
+  }
 
-    @Test("custom with same rawValue as built-in is not equal")
-    func customNotEqualToBuiltIn() {
-        // A custom type with the same string as a built-in should still be distinct
-        #expect(QueueType.custom("classic") != QueueType.classic)
-        #expect(QueueType.custom("quorum") != QueueType.quorum)
-        #expect(QueueType.custom("stream") != QueueType.stream)
-    }
+  @Test("custom with same rawValue as built-in is not equal")
+  func customNotEqualToBuiltIn() {
+    // A custom type with the same string as a built-in should still be distinct
+    #expect(QueueType.custom("classic") != QueueType.classic)
+    #expect(QueueType.custom("quorum") != QueueType.quorum)
+    #expect(QueueType.custom("stream") != QueueType.stream)
+  }
 }

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -39,6 +39,53 @@ struct TestConfig {
   static func openConnection() async throws -> Connection {
     return try await Connection.open(connectionConfiguration())
   }
+
+  // MARK: - TLS Configuration
+
+  /// Path to the directory containing `tls-gen`-generated certificates.
+  /// Set TLS_CERTS_DIR to override; falls back to the local tls-gen checkout.
+  static var tlsCertsDir: String? {
+    ProcessInfo.processInfo.environment["TLS_CERTS_DIR"]
+      ?? {
+        let fallback =
+          NSString(
+            string: "~/Development/Opensource/tls-gen.git/basic/result"
+          ).expandingTildeInPath
+        return FileManager.default.fileExists(atPath: fallback + "/ca_certificate.pem")
+          ? fallback : nil
+      }()
+  }
+
+  static var skipTLSTests: Bool {
+    tlsCertsDir == nil
+  }
+
+  /// Creates a TLS connection configuration using tls-gen certificates
+  static func tlsConnectionConfiguration() throws -> ConnectionConfiguration {
+    guard let certsDir = tlsCertsDir else {
+      throw ConnectionError.protocolError("TLS certificates not found")
+    }
+
+    let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+    let tls = try TLSConfiguration.fromPEMFiles(
+      certificatePath: "\(certsDir)/client_certificate.pem",
+      keyPath: "\(certsDir)/client_key.pem",
+      caCertificatePath: "\(certsDir)/ca_certificate.pem",
+      verifyPeer: false
+    )
+
+    return ConnectionConfiguration(
+      port: 5671,
+      tls: tls,
+      enableTCPNoDelay: !isCI,
+      enableTCPKeepAlive: !isCI
+    )
+  }
+
+  /// Opens a TLS connection using tls-gen certificates
+  static func openTLSConnection() async throws -> Connection {
+    return try await Connection.open(tlsConnectionConfiguration())
+  }
 }
 
 // MARK: - Placeholder Test

--- a/Tests/RecoveryTests/RecoveryCoordinatorTests.swift
+++ b/Tests/RecoveryTests/RecoveryCoordinatorTests.swift
@@ -5,260 +5,261 @@
 //
 // Copyright (c) 2025-2026 Michael S. Klishin
 
-import Testing
 import Foundation
+import Testing
+
 @testable import Recovery
 @testable import Transport
 
 // Thread-safe container for test state
 private actor TestState<T: Sendable> {
-    var value: T
+  var value: T
 
-    init(_ initial: T) {
-        self.value = initial
-    }
+  init(_ initial: T) {
+    self.value = initial
+  }
 
-    func set(_ newValue: T) {
-        value = newValue
-    }
+  func set(_ newValue: T) {
+    value = newValue
+  }
 
-    func get() -> T {
-        value
-    }
+  func get() -> T {
+    value
+  }
 }
 
 @Suite("Recovery Coordinator Tests")
 struct RecoveryCoordinatorTests {
 
-    @Test("Default configuration has automatic recovery enabled")
-    func defaultConfiguration() {
-        let config = RecoveryConfiguration.default
-        #expect(config.automaticRecovery == true)
-        #expect(config.networkRecoveryInterval == 5.0)
-        #expect(config.maxRecoveryAttempts == nil)
-        #expect(config.backoffMultiplier == 2.0)
-        #expect(config.maxRecoveryInterval == 60.0)
+  @Test("Default configuration has automatic recovery enabled")
+  func defaultConfiguration() {
+    let config = RecoveryConfiguration.default
+    #expect(config.automaticRecovery == true)
+    #expect(config.networkRecoveryInterval == 5.0)
+    #expect(config.maxRecoveryAttempts == nil)
+    #expect(config.backoffMultiplier == 2.0)
+    #expect(config.maxRecoveryInterval == 60.0)
+  }
+
+  @Test("No recovery configuration disables automatic recovery")
+  func noRecoveryConfiguration() {
+    let config = RecoveryConfiguration.noRecovery
+    #expect(config.automaticRecovery == false)
+  }
+
+  @Test("Recovery coordinator initial state is idle")
+  func initialStateIsIdle() async {
+    let registry = TopologyRegistry()
+    let coordinator = RecoveryCoordinator(topology: registry)
+
+    let state = await coordinator.currentState
+    if case .idle = state {
+      // Pass
+    } else {
+      Issue.record("Expected idle state, got \(state)")
     }
+  }
 
-    @Test("No recovery configuration disables automatic recovery")
-    func noRecoveryConfiguration() {
-        let config = RecoveryConfiguration.noRecovery
-        #expect(config.automaticRecovery == false)
+  @Test("Recovery does not start when automatic recovery is disabled")
+  func noRecoveryWhenDisabled() async throws {
+    let registry = TopologyRegistry()
+    let config = RecoveryConfiguration.noRecovery
+    let coordinator = RecoveryCoordinator(configuration: config, topology: registry)
+
+    let reconnectCalled = TestState(false)
+    await coordinator.beginRecovery(
+      reconnect: { await reconnectCalled.set(true) },
+      redeclare: { _ in }
+    )
+
+    // Give it a moment
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    #expect(await reconnectCalled.get() == false)
+  }
+
+  @Test("Cancel recovery stops the process")
+  func cancelRecovery() async throws {
+    let registry = TopologyRegistry()
+    let config = RecoveryConfiguration(
+      automaticRecovery: true,
+      networkRecoveryInterval: 10.0  // Long interval so we can cancel
+    )
+    let coordinator = RecoveryCoordinator(configuration: config, topology: registry)
+
+    await coordinator.beginRecovery(
+      reconnect: { throw ConnectionError.notConnected },
+      redeclare: { _ in }
+    )
+
+    // Cancel immediately
+    await coordinator.cancelRecovery()
+
+    let state = await coordinator.currentState
+    if case .idle = state {
+      // Pass
+    } else {
+      Issue.record("Expected idle state after cancel, got \(state)")
     }
+  }
 
-    @Test("Recovery coordinator initial state is idle")
-    func initialStateIsIdle() async {
-        let registry = TopologyRegistry()
-        let coordinator = RecoveryCoordinator(topology: registry)
+  @Test("Reset returns coordinator to idle state")
+  func resetReturnsToIdle() async {
+    let registry = TopologyRegistry()
+    let coordinator = RecoveryCoordinator(topology: registry)
 
-        let state = await coordinator.currentState
-        if case .idle = state {
-            // Pass
-        } else {
-            Issue.record("Expected idle state, got \(state)")
-        }
+    await coordinator.reset()
+
+    let state = await coordinator.currentState
+    if case .idle = state {
+      // Pass
+    } else {
+      Issue.record("Expected idle state after reset, got \(state)")
     }
+  }
 
-    @Test("Recovery does not start when automatic recovery is disabled")
-    func noRecoveryWhenDisabled() async throws {
-        let registry = TopologyRegistry()
-        let config = RecoveryConfiguration.noRecovery
-        let coordinator = RecoveryCoordinator(configuration: config, topology: registry)
+  @Test("Recovery callbacks are called on recovery will begin")
+  func callbackOnRecoveryWillBegin() async throws {
+    let registry = TopologyRegistry()
+    let config = RecoveryConfiguration(
+      automaticRecovery: true,
+      networkRecoveryInterval: 0.01,  // Very short interval
+      maxRecoveryAttempts: 1
+    )
 
-        let reconnectCalled = TestState(false)
-        await coordinator.beginRecovery(
-            reconnect: { await reconnectCalled.set(true) },
-            redeclare: { _ in }
-        )
+    let attemptNumber = TestState<Int?>(nil)
+    let callbacks = RecoveryCallbacks(
+      onRecoveryWillBegin: { attempt in
+        await attemptNumber.set(attempt)
+      }
+    )
+    let coordinator = RecoveryCoordinator(
+      configuration: config,
+      topology: registry,
+      callbacks: callbacks
+    )
 
-        // Give it a moment
-        try await Task.sleep(nanoseconds: 50_000_000)
+    await coordinator.beginRecovery(
+      reconnect: {},  // Succeed immediately
+      redeclare: { _ in }
+    )
 
-        #expect(await reconnectCalled.get() == false)
+    // Wait for recovery to complete
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(await attemptNumber.get() == 1)
+  }
+
+  @Test("Recovery callbacks are called on successful recovery")
+  func callbackOnRecoveryComplete() async throws {
+    let registry = TopologyRegistry()
+    let config = RecoveryConfiguration(
+      automaticRecovery: true,
+      networkRecoveryInterval: 0.01
+    )
+
+    let didComplete = TestState(false)
+    let callbacks = RecoveryCallbacks(
+      onRecoveryDidComplete: {
+        await didComplete.set(true)
+      }
+    )
+    let coordinator = RecoveryCoordinator(
+      configuration: config,
+      topology: registry,
+      callbacks: callbacks
+    )
+
+    await coordinator.beginRecovery(
+      reconnect: {},
+      redeclare: { _ in }
+    )
+
+    // Wait for recovery to complete
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(await didComplete.get() == true)
+
+    let state = await coordinator.currentState
+    if case .recovered = state {
+      // Pass
+    } else {
+      Issue.record("Expected recovered state, got \(state)")
     }
+  }
 
-    @Test("Cancel recovery stops the process")
-    func cancelRecovery() async throws {
-        let registry = TopologyRegistry()
-        let config = RecoveryConfiguration(
-            automaticRecovery: true,
-            networkRecoveryInterval: 10.0  // Long interval so we can cancel
-        )
-        let coordinator = RecoveryCoordinator(configuration: config, topology: registry)
+  @Test("Recovery fails after max attempts exceeded")
+  func failsAfterMaxAttempts() async throws {
+    let registry = TopologyRegistry()
+    let config = RecoveryConfiguration(
+      automaticRecovery: true,
+      networkRecoveryInterval: 0.01,
+      maxRecoveryAttempts: 2
+    )
 
-        await coordinator.beginRecovery(
-            reconnect: { throw ConnectionError.notConnected },
-            redeclare: { _ in }
-        )
+    let failedError = TestState<(any Error)?>(nil)
+    let callbacks = RecoveryCallbacks(
+      onRecoveryDidFail: { error in
+        await failedError.set(error)
+      }
+    )
+    let coordinator = RecoveryCoordinator(
+      configuration: config,
+      topology: registry,
+      callbacks: callbacks
+    )
 
-        // Cancel immediately
-        await coordinator.cancelRecovery()
+    await coordinator.beginRecovery(
+      reconnect: { throw ConnectionError.notConnected },
+      redeclare: { _ in }
+    )
 
-        let state = await coordinator.currentState
-        if case .idle = state {
-            // Pass
-        } else {
-            Issue.record("Expected idle state after cancel, got \(state)")
-        }
+    // Wait for recovery attempts to complete
+    try await Task.sleep(nanoseconds: 200_000_000)
+
+    #expect(await failedError.get() != nil)
+
+    let state = await coordinator.currentState
+    if case .failed = state {
+      // Pass
+    } else {
+      Issue.record("Expected failed state, got \(state)")
     }
+  }
 
-    @Test("Reset returns coordinator to idle state")
-    func resetReturnsToIdle() async {
-        let registry = TopologyRegistry()
-        let coordinator = RecoveryCoordinator(topology: registry)
+  @Test("Topology recovery callbacks are called")
+  func topologyRecoveryCallbacks() async throws {
+    let registry = TopologyRegistry()
+    let config = RecoveryConfiguration(
+      automaticRecovery: true,
+      networkRecoveryInterval: 0.01
+    )
 
-        await coordinator.reset()
+    let topologyBegan = TestState(false)
+    let topologyComplete = TestState(false)
+    let callbacks = RecoveryCallbacks(
+      onTopologyRecoveryDidBegin: {
+        await topologyBegan.set(true)
+      },
+      onTopologyRecoveryDidComplete: {
+        await topologyComplete.set(true)
+      }
+    )
+    let coordinator = RecoveryCoordinator(
+      configuration: config,
+      topology: registry,
+      callbacks: callbacks
+    )
 
-        let state = await coordinator.currentState
-        if case .idle = state {
-            // Pass
-        } else {
-            Issue.record("Expected idle state after reset, got \(state)")
-        }
-    }
+    await coordinator.beginRecovery(
+      reconnect: {},
+      redeclare: { _ in }
+    )
 
-    @Test("Recovery callbacks are called on recovery will begin")
-    func callbackOnRecoveryWillBegin() async throws {
-        let registry = TopologyRegistry()
-        let config = RecoveryConfiguration(
-            automaticRecovery: true,
-            networkRecoveryInterval: 0.01,  // Very short interval
-            maxRecoveryAttempts: 1
-        )
+    // Wait for recovery
+    try await Task.sleep(nanoseconds: 100_000_000)
 
-        let attemptNumber = TestState<Int?>(nil)
-        let callbacks = RecoveryCallbacks(
-            onRecoveryWillBegin: { attempt in
-                await attemptNumber.set(attempt)
-            }
-        )
-        let coordinator = RecoveryCoordinator(
-            configuration: config,
-            topology: registry,
-            callbacks: callbacks
-        )
-
-        await coordinator.beginRecovery(
-            reconnect: { },  // Succeed immediately
-            redeclare: { _ in }
-        )
-
-        // Wait for recovery to complete
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(await attemptNumber.get() == 1)
-    }
-
-    @Test("Recovery callbacks are called on successful recovery")
-    func callbackOnRecoveryComplete() async throws {
-        let registry = TopologyRegistry()
-        let config = RecoveryConfiguration(
-            automaticRecovery: true,
-            networkRecoveryInterval: 0.01
-        )
-
-        let didComplete = TestState(false)
-        let callbacks = RecoveryCallbacks(
-            onRecoveryDidComplete: {
-                await didComplete.set(true)
-            }
-        )
-        let coordinator = RecoveryCoordinator(
-            configuration: config,
-            topology: registry,
-            callbacks: callbacks
-        )
-
-        await coordinator.beginRecovery(
-            reconnect: { },
-            redeclare: { _ in }
-        )
-
-        // Wait for recovery to complete
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(await didComplete.get() == true)
-
-        let state = await coordinator.currentState
-        if case .recovered = state {
-            // Pass
-        } else {
-            Issue.record("Expected recovered state, got \(state)")
-        }
-    }
-
-    @Test("Recovery fails after max attempts exceeded")
-    func failsAfterMaxAttempts() async throws {
-        let registry = TopologyRegistry()
-        let config = RecoveryConfiguration(
-            automaticRecovery: true,
-            networkRecoveryInterval: 0.01,
-            maxRecoveryAttempts: 2
-        )
-
-        let failedError = TestState<(any Error)?>(nil)
-        let callbacks = RecoveryCallbacks(
-            onRecoveryDidFail: { error in
-                await failedError.set(error)
-            }
-        )
-        let coordinator = RecoveryCoordinator(
-            configuration: config,
-            topology: registry,
-            callbacks: callbacks
-        )
-
-        await coordinator.beginRecovery(
-            reconnect: { throw ConnectionError.notConnected },
-            redeclare: { _ in }
-        )
-
-        // Wait for recovery attempts to complete
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        #expect(await failedError.get() != nil)
-
-        let state = await coordinator.currentState
-        if case .failed = state {
-            // Pass
-        } else {
-            Issue.record("Expected failed state, got \(state)")
-        }
-    }
-
-    @Test("Topology recovery callbacks are called")
-    func topologyRecoveryCallbacks() async throws {
-        let registry = TopologyRegistry()
-        let config = RecoveryConfiguration(
-            automaticRecovery: true,
-            networkRecoveryInterval: 0.01
-        )
-
-        let topologyBegan = TestState(false)
-        let topologyComplete = TestState(false)
-        let callbacks = RecoveryCallbacks(
-            onTopologyRecoveryDidBegin: {
-                await topologyBegan.set(true)
-            },
-            onTopologyRecoveryDidComplete: {
-                await topologyComplete.set(true)
-            }
-        )
-        let coordinator = RecoveryCoordinator(
-            configuration: config,
-            topology: registry,
-            callbacks: callbacks
-        )
-
-        await coordinator.beginRecovery(
-            reconnect: { },
-            redeclare: { _ in }
-        )
-
-        // Wait for recovery
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(await topologyBegan.get() == true)
-        #expect(await topologyComplete.get() == true)
-    }
+    #expect(await topologyBegan.get() == true)
+    #expect(await topologyComplete.get() == true)
+  }
 }

--- a/Tests/RecoveryTests/TopologyRegistryTests.swift
+++ b/Tests/RecoveryTests/TopologyRegistryTests.swift
@@ -6,310 +6,317 @@
 // Copyright (c) 2025-2026 Michael S. Klishin
 
 import Testing
-@testable import Recovery
+
 @testable import AMQPProtocol
+@testable import Recovery
 
 @Suite("Topology Registry Tests")
 struct TopologyRegistryTests {
 
-    // MARK: - Exchange Tests
+  // MARK: - Exchange Tests
 
-    @Test("Record and retrieve exchange")
-    func recordExchange() async {
-        let registry = TopologyRegistry()
-        let exchange = RecordedExchange(
-            name: "test.exchange",
-            type: "topic",
-            durable: true,
-            autoDelete: false,
-            internal: false,
-            arguments: [:]
-        )
+  @Test("Record and retrieve exchange")
+  func recordExchange() async {
+    let registry = TopologyRegistry()
+    let exchange = RecordedExchange(
+      name: "test.exchange",
+      type: "topic",
+      durable: true,
+      autoDelete: false,
+      internal: false,
+      arguments: [:]
+    )
 
-        await registry.recordExchange(exchange)
-        let exchanges = await registry.allExchanges()
+    await registry.recordExchange(exchange)
+    let exchanges = await registry.allExchanges()
 
-        #expect(exchanges.count == 1)
-        #expect(exchanges.first?.name == "test.exchange")
-        #expect(exchanges.first?.type == "topic")
-        #expect(exchanges.first?.durable == true)
-    }
+    #expect(exchanges.count == 1)
+    #expect(exchanges.first?.name == "test.exchange")
+    #expect(exchanges.first?.type == "topic")
+    #expect(exchanges.first?.durable == true)
+  }
 
-    @Test("Delete exchange removes exchange and related bindings")
-    func deleteExchange() async {
-        let registry = TopologyRegistry()
+  @Test("Delete exchange removes exchange and related bindings")
+  func deleteExchange() async {
+    let registry = TopologyRegistry()
 
-        let exchange = RecordedExchange(
-            name: "logs",
-            type: "fanout",
-            durable: false,
-            autoDelete: false,
-            internal: false,
-            arguments: [:]
-        )
-        await registry.recordExchange(exchange)
+    let exchange = RecordedExchange(
+      name: "logs",
+      type: "fanout",
+      durable: false,
+      autoDelete: false,
+      internal: false,
+      arguments: [:]
+    )
+    await registry.recordExchange(exchange)
 
-        let queue = RecordedQueue(
-            name: "worker",
-            durable: false,
-            exclusive: false,
-            autoDelete: false,
-            arguments: [:]
-        )
-        await registry.recordQueue(queue)
+    let queue = RecordedQueue(
+      name: "worker",
+      durable: false,
+      exclusive: false,
+      autoDelete: false,
+      arguments: [:]
+    )
+    await registry.recordQueue(queue)
 
-        let binding = RecordedQueueBinding(
-            queue: "worker",
-            exchange: "logs",
-            routingKey: "",
-            arguments: [:]
-        )
-        await registry.recordQueueBinding(binding)
+    let binding = RecordedQueueBinding(
+      queue: "worker",
+      exchange: "logs",
+      routingKey: "",
+      arguments: [:]
+    )
+    await registry.recordQueueBinding(binding)
 
-        await registry.deleteExchange(named: "logs")
+    await registry.deleteExchange(named: "logs")
 
-        let exchanges = await registry.allExchanges()
-        let bindings = await registry.allQueueBindings()
+    let exchanges = await registry.allExchanges()
+    let bindings = await registry.allQueueBindings()
 
-        #expect(exchanges.isEmpty)
-        #expect(bindings.isEmpty)
-    }
+    #expect(exchanges.isEmpty)
+    #expect(bindings.isEmpty)
+  }
 
-    // MARK: - Queue Tests
+  // MARK: - Queue Tests
 
-    @Test("Record and retrieve queue")
-    func recordQueue() async {
-        let registry = TopologyRegistry()
-        let queue = RecordedQueue(
-            name: "my-queue",
-            durable: true,
-            exclusive: false,
-            autoDelete: false,
-            arguments: ["x-message-ttl": .int32(60000)]
-        )
+  @Test("Record and retrieve queue")
+  func recordQueue() async {
+    let registry = TopologyRegistry()
+    let queue = RecordedQueue(
+      name: "my-queue",
+      durable: true,
+      exclusive: false,
+      autoDelete: false,
+      arguments: ["x-message-ttl": .int32(60000)]
+    )
 
-        await registry.recordQueue(queue)
-        let queues = await registry.allQueues()
+    await registry.recordQueue(queue)
+    let queues = await registry.allQueues()
 
-        #expect(queues.count == 1)
-        #expect(queues.first?.name == "my-queue")
-        #expect(queues.first?.durable == true)
-        #expect(queues.first?.arguments["x-message-ttl"]?.intValue == 60000)
-    }
+    #expect(queues.count == 1)
+    #expect(queues.first?.name == "my-queue")
+    #expect(queues.first?.durable == true)
+    #expect(queues.first?.arguments["x-message-ttl"]?.intValue == 60000)
+  }
 
-    @Test("Delete queue removes queue, bindings, and consumers")
-    func deleteQueue() async {
-        let registry = TopologyRegistry()
+  @Test("Delete queue removes queue, bindings, and consumers")
+  func deleteQueue() async {
+    let registry = TopologyRegistry()
 
-        let queue = RecordedQueue(
-            name: "tasks",
-            durable: true,
-            exclusive: false,
-            autoDelete: false,
-            arguments: [:]
-        )
-        await registry.recordQueue(queue)
+    let queue = RecordedQueue(
+      name: "tasks",
+      durable: true,
+      exclusive: false,
+      autoDelete: false,
+      arguments: [:]
+    )
+    await registry.recordQueue(queue)
 
-        let binding = RecordedQueueBinding(
-            queue: "tasks",
-            exchange: "amq.direct",
-            routingKey: "task",
-            arguments: [:]
-        )
-        await registry.recordQueueBinding(binding)
+    let binding = RecordedQueueBinding(
+      queue: "tasks",
+      exchange: "amq.direct",
+      routingKey: "task",
+      arguments: [:]
+    )
+    await registry.recordQueueBinding(binding)
 
-        let consumer = RecordedConsumer(
-            consumerTag: "consumer-1",
-            queue: "tasks",
-            acknowledgementMode: .manual,
-            exclusive: false,
-            arguments: [:]
-        )
-        await registry.recordConsumer(consumer)
+    let consumer = RecordedConsumer(
+      consumerTag: "consumer-1",
+      queue: "tasks",
+      acknowledgementMode: .manual,
+      exclusive: false,
+      arguments: [:]
+    )
+    await registry.recordConsumer(consumer)
 
-        await registry.deleteQueue(named: "tasks")
+    await registry.deleteQueue(named: "tasks")
 
-        let queues = await registry.allQueues()
-        let bindings = await registry.allQueueBindings()
-        let consumers = await registry.allConsumers()
+    let queues = await registry.allQueues()
+    let bindings = await registry.allQueueBindings()
+    let consumers = await registry.allConsumers()
 
-        #expect(queues.isEmpty)
-        #expect(bindings.isEmpty)
-        #expect(consumers.isEmpty)
-    }
+    #expect(queues.isEmpty)
+    #expect(bindings.isEmpty)
+    #expect(consumers.isEmpty)
+  }
 
-    @Test("Update queue name for server-named queue")
-    func updateQueueName() async {
-        let registry = TopologyRegistry()
+  @Test("Update queue name for server-named queue")
+  func updateQueueName() async {
+    let registry = TopologyRegistry()
 
-        let queue = RecordedQueue(
-            name: "amq.gen-old",
-            durable: false,
-            exclusive: true,
-            autoDelete: true,
-            arguments: [:],
-            serverNamed: true
-        )
-        await registry.recordQueue(queue)
+    let queue = RecordedQueue(
+      name: "amq.gen-old",
+      durable: false,
+      exclusive: true,
+      autoDelete: true,
+      arguments: [:],
+      serverNamed: true
+    )
+    await registry.recordQueue(queue)
 
-        let binding = RecordedQueueBinding(
-            queue: "amq.gen-old",
-            exchange: "logs",
-            routingKey: "",
-            arguments: [:]
-        )
-        await registry.recordQueueBinding(binding)
+    let binding = RecordedQueueBinding(
+      queue: "amq.gen-old",
+      exchange: "logs",
+      routingKey: "",
+      arguments: [:]
+    )
+    await registry.recordQueueBinding(binding)
 
-        let consumer = RecordedConsumer(
-            consumerTag: "tag-1",
-            queue: "amq.gen-old",
-            acknowledgementMode: .manual,
-            exclusive: false,
-            arguments: [:]
-        )
-        await registry.recordConsumer(consumer)
+    let consumer = RecordedConsumer(
+      consumerTag: "tag-1",
+      queue: "amq.gen-old",
+      acknowledgementMode: .manual,
+      exclusive: false,
+      arguments: [:]
+    )
+    await registry.recordConsumer(consumer)
 
-        await registry.updateQueueName(from: "amq.gen-old", to: "amq.gen-new")
+    await registry.updateQueueName(from: "amq.gen-old", to: "amq.gen-new")
 
-        let queues = await registry.allQueues()
-        let bindings = await registry.allQueueBindings()
-        let consumers = await registry.allConsumers()
+    let queues = await registry.allQueues()
+    let bindings = await registry.allQueueBindings()
+    let consumers = await registry.allConsumers()
 
-        #expect(queues.count == 1)
-        #expect(queues.first?.name == "amq.gen-new")
-        #expect(bindings.first?.queue == "amq.gen-new")
-        #expect(consumers.first?.queue == "amq.gen-new")
-    }
+    #expect(queues.count == 1)
+    #expect(queues.first?.name == "amq.gen-new")
+    #expect(bindings.first?.queue == "amq.gen-new")
+    #expect(consumers.first?.queue == "amq.gen-new")
+  }
 
-    // MARK: - Binding Tests
+  // MARK: - Binding Tests
 
-    @Test("Record and retrieve queue bindings")
-    func recordQueueBinding() async {
-        let registry = TopologyRegistry()
+  @Test("Record and retrieve queue bindings")
+  func recordQueueBinding() async {
+    let registry = TopologyRegistry()
 
-        let binding1 = RecordedQueueBinding(
-            queue: "q1",
-            exchange: "ex1",
-            routingKey: "key1",
-            arguments: [:]
-        )
-        let binding2 = RecordedQueueBinding(
-            queue: "q1",
-            exchange: "ex1",
-            routingKey: "key2",
-            arguments: [:]
-        )
+    let binding1 = RecordedQueueBinding(
+      queue: "q1",
+      exchange: "ex1",
+      routingKey: "key1",
+      arguments: [:]
+    )
+    let binding2 = RecordedQueueBinding(
+      queue: "q1",
+      exchange: "ex1",
+      routingKey: "key2",
+      arguments: [:]
+    )
 
-        await registry.recordQueueBinding(binding1)
-        await registry.recordQueueBinding(binding2)
+    await registry.recordQueueBinding(binding1)
+    await registry.recordQueueBinding(binding2)
 
-        let bindings = await registry.allQueueBindings()
-        #expect(bindings.count == 2)
-    }
+    let bindings = await registry.allQueueBindings()
+    #expect(bindings.count == 2)
+  }
 
-    @Test("Delete queue binding")
-    func deleteQueueBinding() async {
-        let registry = TopologyRegistry()
+  @Test("Delete queue binding")
+  func deleteQueueBinding() async {
+    let registry = TopologyRegistry()
 
-        let binding = RecordedQueueBinding(
-            queue: "q1",
-            exchange: "ex1",
-            routingKey: "key1",
-            arguments: [:]
-        )
+    let binding = RecordedQueueBinding(
+      queue: "q1",
+      exchange: "ex1",
+      routingKey: "key1",
+      arguments: [:]
+    )
 
-        await registry.recordQueueBinding(binding)
-        await registry.deleteQueueBinding(binding)
+    await registry.recordQueueBinding(binding)
+    await registry.deleteQueueBinding(binding)
 
-        let bindings = await registry.allQueueBindings()
-        #expect(bindings.isEmpty)
-    }
+    let bindings = await registry.allQueueBindings()
+    #expect(bindings.isEmpty)
+  }
 
-    @Test("Record and delete exchange bindings")
-    func exchangeBindings() async {
-        let registry = TopologyRegistry()
+  @Test("Record and delete exchange bindings")
+  func exchangeBindings() async {
+    let registry = TopologyRegistry()
 
-        let binding = RecordedExchangeBinding(
-            destination: "dest.ex",
-            source: "src.ex",
-            routingKey: "*.critical",
-            arguments: [:]
-        )
+    let binding = RecordedExchangeBinding(
+      destination: "dest.ex",
+      source: "src.ex",
+      routingKey: "*.critical",
+      arguments: [:]
+    )
 
-        await registry.recordExchangeBinding(binding)
-        let bindings = await registry.allExchangeBindings()
-        #expect(bindings.count == 1)
+    await registry.recordExchangeBinding(binding)
+    let bindings = await registry.allExchangeBindings()
+    #expect(bindings.count == 1)
 
-        await registry.deleteExchangeBinding(binding)
-        let bindingsAfter = await registry.allExchangeBindings()
-        #expect(bindingsAfter.isEmpty)
-    }
+    await registry.deleteExchangeBinding(binding)
+    let bindingsAfter = await registry.allExchangeBindings()
+    #expect(bindingsAfter.isEmpty)
+  }
 
-    // MARK: - Consumer Tests
+  // MARK: - Consumer Tests
 
-    @Test("Record and retrieve consumer")
-    func recordConsumer() async {
-        let registry = TopologyRegistry()
+  @Test("Record and retrieve consumer")
+  func recordConsumer() async {
+    let registry = TopologyRegistry()
 
-        let consumer = RecordedConsumer(
-            consumerTag: "my-consumer",
-            queue: "tasks",
-            acknowledgementMode: .manual,
-            exclusive: true,
-            arguments: [:]
-        )
+    let consumer = RecordedConsumer(
+      consumerTag: "my-consumer",
+      queue: "tasks",
+      acknowledgementMode: .manual,
+      exclusive: true,
+      arguments: [:]
+    )
 
-        await registry.recordConsumer(consumer)
+    await registry.recordConsumer(consumer)
 
-        let retrieved = await registry.consumer(forTag: "my-consumer")
-        #expect(retrieved?.consumerTag == "my-consumer")
-        #expect(retrieved?.queue == "tasks")
-        #expect(retrieved?.exclusive == true)
-    }
+    let retrieved = await registry.consumer(forTag: "my-consumer")
+    #expect(retrieved?.consumerTag == "my-consumer")
+    #expect(retrieved?.queue == "tasks")
+    #expect(retrieved?.exclusive == true)
+  }
 
-    @Test("Delete consumer")
-    func deleteConsumer() async {
-        let registry = TopologyRegistry()
+  @Test("Delete consumer")
+  func deleteConsumer() async {
+    let registry = TopologyRegistry()
 
-        let consumer = RecordedConsumer(
-            consumerTag: "tag-to-delete",
-            queue: "q1",
-            acknowledgementMode: .manual,
-            exclusive: false,
-            arguments: [:]
-        )
+    let consumer = RecordedConsumer(
+      consumerTag: "tag-to-delete",
+      queue: "q1",
+      acknowledgementMode: .manual,
+      exclusive: false,
+      arguments: [:]
+    )
 
-        await registry.recordConsumer(consumer)
-        await registry.deleteConsumer(tag: "tag-to-delete")
+    await registry.recordConsumer(consumer)
+    await registry.deleteConsumer(tag: "tag-to-delete")
 
-        let retrieved = await registry.consumer(forTag: "tag-to-delete")
-        #expect(retrieved == nil)
-    }
+    let retrieved = await registry.consumer(forTag: "tag-to-delete")
+    #expect(retrieved == nil)
+  }
 
-    // MARK: - Clear Tests
+  // MARK: - Clear Tests
 
-    @Test("Clear removes all entries")
-    func clear() async {
-        let registry = TopologyRegistry()
+  @Test("Clear removes all entries")
+  func clear() async {
+    let registry = TopologyRegistry()
 
-        await registry.recordExchange(RecordedExchange(
-            name: "ex1", type: "direct", durable: false, autoDelete: false, internal: false, arguments: [:]
-        ))
-        await registry.recordQueue(RecordedQueue(
-            name: "q1", durable: false, exclusive: false, autoDelete: false, arguments: [:]
-        ))
-        await registry.recordQueueBinding(RecordedQueueBinding(
-            queue: "q1", exchange: "ex1", routingKey: "", arguments: [:]
-        ))
-        await registry.recordConsumer(RecordedConsumer(
-            consumerTag: "c1", queue: "q1", acknowledgementMode: .manual, exclusive: false, arguments: [:]
-        ))
+    await registry.recordExchange(
+      RecordedExchange(
+        name: "ex1", type: "direct", durable: false, autoDelete: false, internal: false,
+        arguments: [:]
+      ))
+    await registry.recordQueue(
+      RecordedQueue(
+        name: "q1", durable: false, exclusive: false, autoDelete: false, arguments: [:]
+      ))
+    await registry.recordQueueBinding(
+      RecordedQueueBinding(
+        queue: "q1", exchange: "ex1", routingKey: "", arguments: [:]
+      ))
+    await registry.recordConsumer(
+      RecordedConsumer(
+        consumerTag: "c1", queue: "q1", acknowledgementMode: .manual, exclusive: false,
+        arguments: [:]
+      ))
 
-        await registry.clear()
+    await registry.clear()
 
-        #expect(await registry.allExchanges().isEmpty)
-        #expect(await registry.allQueues().isEmpty)
-        #expect(await registry.allQueueBindings().isEmpty)
-        #expect(await registry.allConsumers().isEmpty)
-    }
+    #expect(await registry.allExchanges().isEmpty)
+    #expect(await registry.allQueues().isEmpty)
+    #expect(await registry.allQueueBindings().isEmpty)
+    #expect(await registry.allConsumers().isEmpty)
+  }
 }

--- a/Tests/TransportTests/ConnectionConfigurationTests.swift
+++ b/Tests/TransportTests/ConnectionConfigurationTests.swift
@@ -6,118 +6,120 @@
 // Copyright (c) 2025-2026 Michael S. Klishin
 
 import Testing
+
 @testable import Transport
 
 @Suite("ConnectionConfiguration Tests")
 struct ConnectionConfigurationTests {
 
-    // MARK: - Default Values
+  // MARK: - Default Values
 
-    @Test("Default configuration has expected values")
-    func defaultConfiguration() {
-        let config = ConnectionConfiguration()
-        #expect(config.host == "localhost")
-        #expect(config.port == 5672)
-        #expect(config.virtualHost == "/")
-        #expect(config.username == "guest")
-        #expect(config.password == "guest")
-        #expect(config.tls == nil)
-        #expect(config.heartbeat == 60)
-        #expect(config.frameMax == 131072)
-        #expect(config.channelMax == 2047)
+  @Test("Default configuration has expected values")
+  func defaultConfiguration() {
+    let config = ConnectionConfiguration()
+    #expect(config.host == "localhost")
+    #expect(config.port == 5672)
+    #expect(config.virtualHost == "/")
+    #expect(config.username == "guest")
+    #expect(config.password == "guest")
+    #expect(config.tls == nil)
+    #expect(config.heartbeat == 60)
+    #expect(config.frameMax == 131072)
+    #expect(config.channelMax == 2047)
+  }
+
+  // MARK: - URI Parsing
+
+  @Test("Parse simple AMQP URI")
+  func parseSimpleURI() throws {
+    let config = try ConnectionConfiguration.from(uri: "amqp://localhost")
+    #expect(config.host == "localhost")
+    #expect(config.port == 5672)
+    #expect(config.tls == nil)
+  }
+
+  @Test("Parse URI with credentials")
+  func parseURIWithCredentials() throws {
+    let config = try ConnectionConfiguration.from(uri: "amqp://user:pass@rabbit.example.com")
+    #expect(config.host == "rabbit.example.com")
+    #expect(config.username == "user")
+    #expect(config.password == "pass")
+  }
+
+  @Test("Parse URI with port")
+  func parseURIWithPort() throws {
+    let config = try ConnectionConfiguration.from(uri: "amqp://localhost:5673")
+    #expect(config.port == 5673)
+  }
+
+  @Test("Parse URI with vhost")
+  func parseURIWithVhost() throws {
+    let config = try ConnectionConfiguration.from(uri: "amqp://localhost/myvhost")
+    #expect(config.virtualHost == "myvhost")
+  }
+
+  @Test("Parse AMQPS URI enables TLS")
+  func parseAMQPSURI() throws {
+    let config = try ConnectionConfiguration.from(uri: "amqps://secure.example.com")
+    #expect(config.tls != nil)
+    #expect(config.port == 5671)
+  }
+
+  @Test("Parse AMQPS URI with non-standard port preserves port")
+  func parseAMQPSURIWithPort() throws {
+    let config = try ConnectionConfiguration.from(uri: "amqps://secure.example.com:5673")
+    #expect(config.port == 5673)
+    #expect(config.tls != nil)
+  }
+
+  @Test("Parse full URI")
+  func parseFullURI() throws {
+    let config = try ConnectionConfiguration.from(
+      uri: "amqp://admin:secret@rabbit.local:5673/production")
+    #expect(config.host == "rabbit.local")
+    #expect(config.port == 5673)
+    #expect(config.username == "admin")
+    #expect(config.password == "secret")
+    #expect(config.virtualHost == "production")
+  }
+
+  @Test("Empty URI throws error")
+  func emptyURIThrows() {
+    #expect(throws: ConnectionError.self) {
+      _ = try ConnectionConfiguration.from(uri: "")
     }
+  }
 
-    // MARK: - URI Parsing
+  // MARK: - Write Buffer Configuration
 
-    @Test("Parse simple AMQP URI")
-    func parseSimpleURI() throws {
-        let config = try ConnectionConfiguration.from(uri: "amqp://localhost")
-        #expect(config.host == "localhost")
-        #expect(config.port == 5672)
-        #expect(config.tls == nil)
-    }
+  @Test("Write buffer configuration defaults")
+  func writeBufferDefaults() {
+    let config = ConnectionConfiguration()
+    #expect(config.writeBufferFlushThreshold == 64)
+  }
 
-    @Test("Parse URI with credentials")
-    func parseURIWithCredentials() throws {
-        let config = try ConnectionConfiguration.from(uri: "amqp://user:pass@rabbit.example.com")
-        #expect(config.host == "rabbit.example.com")
-        #expect(config.username == "user")
-        #expect(config.password == "pass")
-    }
-
-    @Test("Parse URI with port")
-    func parseURIWithPort() throws {
-        let config = try ConnectionConfiguration.from(uri: "amqp://localhost:5673")
-        #expect(config.port == 5673)
-    }
-
-    @Test("Parse URI with vhost")
-    func parseURIWithVhost() throws {
-        let config = try ConnectionConfiguration.from(uri: "amqp://localhost/myvhost")
-        #expect(config.virtualHost == "myvhost")
-    }
-
-    @Test("Parse AMQPS URI enables TLS")
-    func parseAMQPSURI() throws {
-        let config = try ConnectionConfiguration.from(uri: "amqps://secure.example.com")
-        #expect(config.tls != nil)
-        #expect(config.port == 5671)
-    }
-
-    @Test("Parse AMQPS URI with non-standard port preserves port")
-    func parseAMQPSURIWithPort() throws {
-        let config = try ConnectionConfiguration.from(uri: "amqps://secure.example.com:5673")
-        #expect(config.port == 5673)
-        #expect(config.tls != nil)
-    }
-
-    @Test("Parse full URI")
-    func parseFullURI() throws {
-        let config = try ConnectionConfiguration.from(uri: "amqp://admin:secret@rabbit.local:5673/production")
-        #expect(config.host == "rabbit.local")
-        #expect(config.port == 5673)
-        #expect(config.username == "admin")
-        #expect(config.password == "secret")
-        #expect(config.virtualHost == "production")
-    }
-
-    @Test("Empty URI throws error")
-    func emptyURIThrows() {
-        #expect(throws: ConnectionError.self) {
-            _ = try ConnectionConfiguration.from(uri: "")
-        }
-    }
-
-    // MARK: - Write Buffer Configuration
-
-    @Test("Write buffer configuration defaults")
-    func writeBufferDefaults() {
-        let config = ConnectionConfiguration()
-        #expect(config.writeBufferFlushThreshold == 64)
-    }
-
-    @Test("Custom write buffer configuration")
-    func customWriteBuffer() {
-        let config = ConnectionConfiguration(
-            writeBufferFlushThreshold: 128
-        )
-        #expect(config.writeBufferFlushThreshold == 128)
-    }
+  @Test("Custom write buffer configuration")
+  func customWriteBuffer() {
+    let config = ConnectionConfiguration(
+      writeBufferFlushThreshold: 128
+    )
+    #expect(config.writeBufferFlushThreshold == 128)
+  }
 }
 
 @Suite("TLSConfiguration Tests")
 struct TLSConfigurationTests {
 
-    @Test("Default client configuration")
-    func defaultClientConfig() {
-        let config = TLSConfiguration.makeClientConfiguration()
-        #expect(config.certificateVerification == .fullVerification)
-        #expect(config.minimumTLSVersion == .tlsv12)
-    }
+  @Test("Default client configuration")
+  func defaultClientConfig() {
+    let config = TLSConfiguration.makeClientConfiguration()
+    #expect(config.certificateVerification == .fullVerification)
+    #expect(config.minimumTLSVersion == .tlsv12)
+  }
 
-    @Test("Insecure configuration disables verification")
-    func insecureConfig() {
-        let config = TLSConfiguration.insecure()
-        #expect(config.certificateVerification == .none)
-    }
+  @Test("Insecure configuration disables verification")
+  func insecureConfig() {
+    let config = TLSConfiguration.insecure()
+    #expect(config.certificateVerification == .none)
+  }
 }

--- a/Tests/TransportTests/ErrorHandlingTests.swift
+++ b/Tests/TransportTests/ErrorHandlingTests.swift
@@ -6,172 +6,173 @@
 // Copyright (c) 2025-2026 Michael S. Klishin
 
 import Testing
+
 @testable import Transport
 
 @Suite("Error Handling Tests")
 struct ErrorHandlingTests {
 
-    // MARK: - ConnectionError Tests
+  // MARK: - ConnectionError Tests
 
-    @Test("ConnectionError has error descriptions")
-    func errorDescriptions() {
-        let errors: [ConnectionError] = [
-            .invalidURI("amqp://bad"),
-            .notConnected,
-            .alreadyConnected,
-            .heartbeatTimeout,
-            .authenticationFailed(username: "guest", vhost: "/", reason: "ACCESS_REFUSED"),
-            .protocolError("Bad frame"),
-            .connectionClosed(replyCode: 320, replyText: "CONNECTION_FORCED"),
-            .channelClosed(replyCode: 404, replyText: "NOT_FOUND", classID: 50, methodID: 10)
-        ]
+  @Test("ConnectionError has error descriptions")
+  func errorDescriptions() {
+    let errors: [ConnectionError] = [
+      .invalidURI("amqp://bad"),
+      .notConnected,
+      .alreadyConnected,
+      .heartbeatTimeout,
+      .authenticationFailed(username: "guest", vhost: "/", reason: "ACCESS_REFUSED"),
+      .protocolError("Bad frame"),
+      .connectionClosed(replyCode: 320, replyText: "CONNECTION_FORCED"),
+      .channelClosed(replyCode: 404, replyText: "NOT_FOUND", classID: 50, methodID: 10),
+    ]
 
-        for error in errors {
-            #expect(error.errorDescription != nil)
-            #expect(!error.errorDescription!.isEmpty)
-        }
+    for error in errors {
+      #expect(error.errorDescription != nil)
+      #expect(!error.errorDescription!.isEmpty)
     }
+  }
 
-    @Test("ConnectionError has recovery suggestions")
-    func recoverySuggestions() {
-        let errors: [ConnectionError] = [
-            .invalidURI("bad"),
-            .notConnected,
-            .alreadyConnected,
-            .heartbeatTimeout,
-            .authenticationFailed(username: "guest", vhost: "/", reason: "test")
-        ]
+  @Test("ConnectionError has recovery suggestions")
+  func recoverySuggestions() {
+    let errors: [ConnectionError] = [
+      .invalidURI("bad"),
+      .notConnected,
+      .alreadyConnected,
+      .heartbeatTimeout,
+      .authenticationFailed(username: "guest", vhost: "/", reason: "test"),
+    ]
 
-        for error in errors {
-            #expect(error.recoverySuggestion != nil)
-        }
+    for error in errors {
+      #expect(error.recoverySuggestion != nil)
     }
+  }
 
-    @Test("Channel closed error is soft error for 404")
-    func channelClosedIsSoftError() {
-        let error = ConnectionError.channelClosed(
-            replyCode: 404,
-            replyText: "NOT_FOUND",
-            classID: 50,
-            methodID: 10
-        )
-        #expect(error.isSoftError == true)
-        #expect(error.isHardError == false)
+  @Test("Channel closed error is soft error for 404")
+  func channelClosedIsSoftError() {
+    let error = ConnectionError.channelClosed(
+      replyCode: 404,
+      replyText: "NOT_FOUND",
+      classID: 50,
+      methodID: 10
+    )
+    #expect(error.isSoftError == true)
+    #expect(error.isHardError == false)
+  }
+
+  @Test("Connection closed error is hard error")
+  func connectionClosedIsHardError() {
+    let error = ConnectionError.connectionClosed(
+      replyCode: 320,
+      replyText: "CONNECTION_FORCED"
+    )
+    #expect(error.isHardError == true)
+    #expect(error.isSoftError == false)
+  }
+
+  @Test("Heartbeat timeout is hard error")
+  func heartbeatTimeoutIsHardError() {
+    let error = ConnectionError.heartbeatTimeout
+    #expect(error.isHardError == true)
+  }
+
+  @Test("Authentication failed is hard error")
+  func authFailedIsHardError() {
+    let error = ConnectionError.authenticationFailed(
+      username: "guest",
+      vhost: "/",
+      reason: "ACCESS_REFUSED"
+    )
+    #expect(error.isHardError == true)
+  }
+
+  // MARK: - AMQPReplyCode Tests
+
+  @Test("Soft error codes are classified correctly")
+  func softErrorCodes() {
+    let softCodes: [AMQPReplyCode] = [
+      .contentTooLarge,
+      .noRoute,
+      .noConsumers,
+      .accessRefused,
+      .notFound,
+      .resourceLocked,
+      .preconditionFailed,
+    ]
+
+    for code in softCodes {
+      #expect(code.isSoftError == true, "Expected \(code) to be soft error")
+      #expect(code.isHardError == false, "Expected \(code) not to be hard error")
     }
+  }
 
-    @Test("Connection closed error is hard error")
-    func connectionClosedIsHardError() {
-        let error = ConnectionError.connectionClosed(
-            replyCode: 320,
-            replyText: "CONNECTION_FORCED"
-        )
-        #expect(error.isHardError == true)
-        #expect(error.isSoftError == false)
+  @Test("Hard error codes are classified correctly")
+  func hardErrorCodes() {
+    let hardCodes: [AMQPReplyCode] = [
+      .connectionForced,
+      .invalidPath,
+      .frameError,
+      .syntaxError,
+      .commandInvalid,
+      .channelError,
+      .unexpectedFrame,
+      .resourceError,
+      .notAllowed,
+      .notImplemented,
+      .internalError,
+    ]
+
+    for code in hardCodes {
+      #expect(code.isHardError == true, "Expected \(code) to be hard error")
+      #expect(code.isSoftError == false, "Expected \(code) not to be soft error")
     }
+  }
 
-    @Test("Heartbeat timeout is hard error")
-    func heartbeatTimeoutIsHardError() {
-        let error = ConnectionError.heartbeatTimeout
-        #expect(error.isHardError == true)
+  @Test("Success code is neither soft nor hard error")
+  func successCode() {
+    let code = AMQPReplyCode.success
+    #expect(code.isSoftError == false)
+    #expect(code.isHardError == false)
+  }
+
+  @Test("Reply codes have recovery suggestions")
+  func replyCodeRecoverySuggestions() {
+    let codes: [AMQPReplyCode] = [
+      .contentTooLarge,
+      .noRoute,
+      .notFound,
+      .preconditionFailed,
+      .connectionForced,
+      .frameError,
+      .resourceError,
+    ]
+
+    for code in codes {
+      let suggestion = code.recoverySuggestion(isChannel: true)
+      #expect(suggestion != nil, "Expected \(code) to have recovery suggestion")
     }
+  }
 
-    @Test("Authentication failed is hard error")
-    func authFailedIsHardError() {
-        let error = ConnectionError.authenticationFailed(
-            username: "guest",
-            vhost: "/",
-            reason: "ACCESS_REFUSED"
-        )
-        #expect(error.isHardError == true)
-    }
-
-    // MARK: - AMQPReplyCode Tests
-
-    @Test("Soft error codes are classified correctly")
-    func softErrorCodes() {
-        let softCodes: [AMQPReplyCode] = [
-            .contentTooLarge,
-            .noRoute,
-            .noConsumers,
-            .accessRefused,
-            .notFound,
-            .resourceLocked,
-            .preconditionFailed
-        ]
-
-        for code in softCodes {
-            #expect(code.isSoftError == true, "Expected \(code) to be soft error")
-            #expect(code.isHardError == false, "Expected \(code) not to be hard error")
-        }
-    }
-
-    @Test("Hard error codes are classified correctly")
-    func hardErrorCodes() {
-        let hardCodes: [AMQPReplyCode] = [
-            .connectionForced,
-            .invalidPath,
-            .frameError,
-            .syntaxError,
-            .commandInvalid,
-            .channelError,
-            .unexpectedFrame,
-            .resourceError,
-            .notAllowed,
-            .notImplemented,
-            .internalError
-        ]
-
-        for code in hardCodes {
-            #expect(code.isHardError == true, "Expected \(code) to be hard error")
-            #expect(code.isSoftError == false, "Expected \(code) not to be soft error")
-        }
-    }
-
-    @Test("Success code is neither soft nor hard error")
-    func successCode() {
-        let code = AMQPReplyCode.success
-        #expect(code.isSoftError == false)
-        #expect(code.isHardError == false)
-    }
-
-    @Test("Reply codes have recovery suggestions")
-    func replyCodeRecoverySuggestions() {
-        let codes: [AMQPReplyCode] = [
-            .contentTooLarge,
-            .noRoute,
-            .notFound,
-            .preconditionFailed,
-            .connectionForced,
-            .frameError,
-            .resourceError
-        ]
-
-        for code in codes {
-            let suggestion = code.recoverySuggestion(isChannel: true)
-            #expect(suggestion != nil, "Expected \(code) to have recovery suggestion")
-        }
-    }
-
-    @Test("Reply code raw values match AMQP spec")
-    func replyCodeRawValues() {
-        #expect(AMQPReplyCode.success.rawValue == 200)
-        #expect(AMQPReplyCode.contentTooLarge.rawValue == 311)
-        #expect(AMQPReplyCode.noRoute.rawValue == 312)
-        #expect(AMQPReplyCode.noConsumers.rawValue == 313)
-        #expect(AMQPReplyCode.connectionForced.rawValue == 320)
-        #expect(AMQPReplyCode.invalidPath.rawValue == 402)
-        #expect(AMQPReplyCode.accessRefused.rawValue == 403)
-        #expect(AMQPReplyCode.notFound.rawValue == 404)
-        #expect(AMQPReplyCode.resourceLocked.rawValue == 405)
-        #expect(AMQPReplyCode.preconditionFailed.rawValue == 406)
-        #expect(AMQPReplyCode.frameError.rawValue == 501)
-        #expect(AMQPReplyCode.syntaxError.rawValue == 502)
-        #expect(AMQPReplyCode.commandInvalid.rawValue == 503)
-        #expect(AMQPReplyCode.channelError.rawValue == 504)
-        #expect(AMQPReplyCode.unexpectedFrame.rawValue == 505)
-        #expect(AMQPReplyCode.resourceError.rawValue == 506)
-        #expect(AMQPReplyCode.notAllowed.rawValue == 530)
-        #expect(AMQPReplyCode.notImplemented.rawValue == 540)
-        #expect(AMQPReplyCode.internalError.rawValue == 541)
-    }
+  @Test("Reply code raw values match AMQP spec")
+  func replyCodeRawValues() {
+    #expect(AMQPReplyCode.success.rawValue == 200)
+    #expect(AMQPReplyCode.contentTooLarge.rawValue == 311)
+    #expect(AMQPReplyCode.noRoute.rawValue == 312)
+    #expect(AMQPReplyCode.noConsumers.rawValue == 313)
+    #expect(AMQPReplyCode.connectionForced.rawValue == 320)
+    #expect(AMQPReplyCode.invalidPath.rawValue == 402)
+    #expect(AMQPReplyCode.accessRefused.rawValue == 403)
+    #expect(AMQPReplyCode.notFound.rawValue == 404)
+    #expect(AMQPReplyCode.resourceLocked.rawValue == 405)
+    #expect(AMQPReplyCode.preconditionFailed.rawValue == 406)
+    #expect(AMQPReplyCode.frameError.rawValue == 501)
+    #expect(AMQPReplyCode.syntaxError.rawValue == 502)
+    #expect(AMQPReplyCode.commandInvalid.rawValue == 503)
+    #expect(AMQPReplyCode.channelError.rawValue == 504)
+    #expect(AMQPReplyCode.unexpectedFrame.rawValue == 505)
+    #expect(AMQPReplyCode.resourceError.rawValue == 506)
+    #expect(AMQPReplyCode.notAllowed.rawValue == 530)
+    #expect(AMQPReplyCode.notImplemented.rawValue == 540)
+    #expect(AMQPReplyCode.internalError.rawValue == 541)
+  }
 }


### PR DESCRIPTION
Plus multiple drive-by changes found during the
investigation and the necessary infrastructure
for testing TLS-enabled connection
the same way other clients approach it:
a configurable [`tls-gen`](https://github.com/rabbitmq/tls-gen) location
and a separate set of test suites.